### PR TITLE
chore(ci): Upgrade Node.js to 22 in dependency-update workflow

### DIFF
--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -22,7 +22,7 @@ permissions:
   pull-requests: write
 
 env:
-  NODE_VERSION: '18'
+  NODE_VERSION: '22'
 
 jobs:
   update-dependencies:


### PR DESCRIPTION
# 🔧 Node.js Version Consistency Fix

## Summary
Updates the dependency-update workflow to use Node.js 22, aligning with the project-wide Node.js upgrade.

## Changes
- `NODE_VERSION: '18'` → `NODE_VERSION: '22'`

## Context
All other configurations were updated to Node.js 22:
- ✅ Lambda runtime (`nodejs22.x`)
- ✅ Dockerfile (`node:22-alpine`)
- ✅ package.json (`engines.node >= 22.0.0`)
- ✅ .nvmrc (`22`)
- ✅ ci-cd.yml (`NODE_VERSION: '22'`)
- ✅ security-scan.yml (`NODE_VERSION: '22'`)
- ❌ dependency-update.yml ← **This PR fixes it**

## Impact
- Ensures dependency updates are tested with the same Node.js version used in production
- Prevents compatibility issues from testing on older Node versions