### PR TITLE
ci: gate health check on origin and add free-tier Cloudflare probe bypass

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -638,38 +638,54 @@ jobs:
       - name: 🧪 Post-Deployment Health Check
         id: health_check
         run: |
-          echo "🔍 Running health checks..."
-          
+          echo "🔍 Running health checks against the API Gateway origin..."
+
+          # Gate on the API Gateway invoke URL (origin), not the Cloudflare-fronted
+          # domain. Cloudflare WAF/bot-management can return 403 to CI runner IPs,
+          # which produced false-negative deploy failures even when the app is healthy.
+          ORIGIN_URL="${{ steps.deploy.outputs.api_url }}"
+          echo "🌐 Origin: $ORIGIN_URL"
+
           MAX_RETRIES=5
           RETRY_COUNT=0
-          
+          HTTP_STATUS="000"
+
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://www.${{ env.DOMAIN_NAME }}/health" || echo "000")
-            
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$ORIGIN_URL/health" || echo "000")
+
             if [ "$HTTP_STATUS" = "200" ]; then
-              echo "✅ Health check passed (Status: $HTTP_STATUS)"
+              echo "✅ Origin health check passed (Status: $HTTP_STATUS)"
               break
             fi
-            
+
             RETRY_COUNT=$((RETRY_COUNT + 1))
             echo "⏳ Retry $RETRY_COUNT/$MAX_RETRIES (Status: $HTTP_STATUS)"
             sleep 10
           done
-          
+
           if [ "$HTTP_STATUS" != "200" ]; then
-            echo "❌ Health check failed after $MAX_RETRIES retries"
+            echo "❌ Origin health check failed after $MAX_RETRIES retries"
             exit 1
           fi
-          
-          # Test main page
-          MAIN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://www.${{ env.DOMAIN_NAME }}/" || echo "000")
-          echo "📄 Main page status: $MAIN_STATUS"
-          
+
+          # Test the origin main page (also bypasses Cloudflare)
+          MAIN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$ORIGIN_URL/" || echo "000")
+          echo "📄 Origin main page status: $MAIN_STATUS"
+
           if [ "$MAIN_STATUS" != "200" ]; then
-            echo "❌ Main page check failed"
+            echo "❌ Origin main page check failed"
             exit 1
           fi
-          
+
+          # Public domain check (through Cloudflare) is informational only.
+          # Do not fail the deploy on this: Cloudflare may 403 the runner IP.
+          PUBLIC_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://www.${{ env.DOMAIN_NAME }}/health" || echo "000")
+          if [ "$PUBLIC_STATUS" = "200" ]; then
+            echo "✅ Public domain reachable through Cloudflare (Status: $PUBLIC_STATUS)"
+          else
+            echo "::warning::Public domain returned $PUBLIC_STATUS via Cloudflare (likely WAF/bot-management blocking the runner IP). Origin is healthy, so the deploy is considered successful."
+          fi
+
           echo "✅ All health checks passed!"
 
       - name: 🔙 Rollback on Failure

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -731,7 +731,7 @@ jobs:
               echo "::warning::Public domain returned $PUBLIC_STATUS via Cloudflare (edge is up but filtering the runner IP; check the CF_PROBE_SECRET WAF rule). Origin is healthy, so the deploy is considered successful."
               ;;
             000|5*)
-              echo "❌ Public domain check failed at the Cloudflare edge (Status: $PUBLIC_STATUS) — DNS/TLS down or edge cannot reach origin"
+              echo "❌ Public domain check failed at the Cloudflare edge (Status: $PUBLIC_STATUS): DNS/TLS down or edge cannot reach origin"
               exit 1
               ;;
             *)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -311,6 +311,7 @@ jobs:
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_custom_domain_target: "d-hctzaliyt6.execute-api.eu-north-1.amazonaws.com"
           TF_VAR_profile_domain_target: ""
+          TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
 
       - name: 📤 Upload Terraform Plan
         uses: actions/upload-artifact@v4
@@ -363,6 +364,38 @@ jobs:
               return `🔵 **${label}:** review plan below`;
             };
 
+            // Parse the raw plan into a per-resource change list so reviewers
+            // can see exactly what changes without expanding the raw output.
+            const changeRows = (text, label) => {
+              if (!text) return [];
+              const re = /^\s*#\s+(.+?)\s+(?:will be|must be)\s+(created|destroyed|replaced|updated in-place)/gm;
+              const rows = [];
+              let m;
+              while ((m = re.exec(text)) !== null) {
+                const action = m[2];
+                const sym = action === 'created' ? '🟢 create'
+                  : action === 'destroyed' ? '🔴 destroy'
+                  : action === 'replaced' ? '🟠 replace'
+                  : '🟡 update';
+                rows.push(`| ${label} | \`${m[1]}\` | ${sym} |`);
+              }
+              return rows;
+            };
+
+            const changeTable = () => {
+              const rows = [...changeRows(awsPlan, 'AWS'), ...changeRows(cfPlan, 'Cloudflare')];
+              if (!rows.length) {
+                return ['_No resource changes planned. Both providers match their configuration._'];
+              }
+              return [
+                '### 📋 Planned resource changes',
+                '',
+                '| Provider | Resource | Action |',
+                '| :--- | :--- | :---: |',
+                ...rows,
+              ];
+            };
+
             const fmtBlock = (text) => {
               if (!text) return '_No plan output captured._';
               const body = text.length > MAX
@@ -390,6 +423,8 @@ jobs:
               `| Init | ${icon('${{ steps.init.outcome }}')} | ${icon('${{ steps.cf_init.outcome }}')} |`,
               `| Validate | ${icon('${{ steps.validate.outcome }}')} | ${icon('${{ steps.cf_validate.outcome }}')} |`,
               `| Plan | ${icon('${{ steps.plan.outcome }}')} | ${icon('${{ steps.cf_plan.outcome }}')} |`,
+              '',
+              ...changeTable(),
               '',
               '<details><summary>📄 AWS plan output</summary>',
               '',
@@ -605,6 +640,7 @@ jobs:
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_custom_domain_target: "d-hctzaliyt6.execute-api.eu-north-1.amazonaws.com"
           TF_VAR_profile_domain_target: ${{ env.PROFILE_DOMAIN_TARGET }}
+          TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
 
       - name: 🚀 Deploy Lambda Function
         id: deploy
@@ -677,14 +713,31 @@ jobs:
             exit 1
           fi
 
-          # Public domain check (through Cloudflare) is informational only.
-          # Do not fail the deploy on this: Cloudflare may 403 the runner IP.
-          PUBLIC_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://www.${{ env.DOMAIN_NAME }}/health" || echo "000")
-          if [ "$PUBLIC_STATUS" = "200" ]; then
-            echo "✅ Public domain reachable through Cloudflare (Status: $PUBLIC_STATUS)"
-          else
-            echo "::warning::Public domain returned $PUBLIC_STATUS via Cloudflare (likely WAF/bot-management blocking the runner IP). Origin is healthy, so the deploy is considered successful."
-          fi
+          # Public domain check (through Cloudflare). The probe sends a secret
+          # header that a Cloudflare WAF rule (terraform/cloudflare) uses to skip
+          # bot management, so a CI runner IP is not falsely blocked. We classify
+          # the result: 200 = healthy; 403/429/503 = edge is up but still
+          # filtering (warn only); 000 / 5xx / 52x = a real edge or origin
+          # failure that must fail the deploy.
+          PUBLIC_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "x-ci-probe: ${{ secrets.CF_PROBE_SECRET }}" \
+            "https://www.${{ env.DOMAIN_NAME }}/health" || echo "000")
+
+          case "$PUBLIC_STATUS" in
+            200)
+              echo "✅ Public domain healthy through Cloudflare (Status: $PUBLIC_STATUS)"
+              ;;
+            403|429|503)
+              echo "::warning::Public domain returned $PUBLIC_STATUS via Cloudflare (edge is up but filtering the runner IP; check the CF_PROBE_SECRET WAF rule). Origin is healthy, so the deploy is considered successful."
+              ;;
+            000|5*)
+              echo "❌ Public domain check failed at the Cloudflare edge (Status: $PUBLIC_STATUS) — DNS/TLS down or edge cannot reach origin"
+              exit 1
+              ;;
+            *)
+              echo "::warning::Public domain returned unexpected status $PUBLIC_STATUS via Cloudflare. Origin is healthy, so the deploy is considered successful."
+              ;;
+          esac
 
           echo "✅ All health checks passed!"
 
@@ -737,28 +790,32 @@ jobs:
           echo "🔥 Running smoke tests against production..."
           
           BASE_URL="https://www.${{ env.DOMAIN_NAME }}"
+          # Secret header so the Cloudflare WAF bypass rule lets the runner IP
+          # through bot management instead of returning a false-negative 403.
+          PROBE_HEADER="x-ci-probe: ${{ secrets.CF_PROBE_SECRET }}"
           
           # Test 1: Homepage loads
           echo "📄 Testing homepage..."
-          curl -sf "$BASE_URL/" > /dev/null
+          curl -sf -H "$PROBE_HEADER" "$BASE_URL/" > /dev/null
           echo "✅ Homepage OK"
           
           # Test 2: Health endpoint
           echo "💚 Testing health endpoint..."
-          HEALTH=$(curl -sf "$BASE_URL/health")
+          HEALTH=$(curl -sf -H "$PROBE_HEADER" "$BASE_URL/health")
           echo "Health response: $HEALTH"
           echo "✅ Health endpoint OK"
           
           # Test 3: Static assets
           echo "📁 Testing static assets..."
-          curl -sf "$BASE_URL/css/modern-style.css" > /dev/null
+          curl -sf -H "$PROBE_HEADER" "$BASE_URL/css/modern-style.css" > /dev/null
           echo "✅ CSS OK"
-          curl -sf "$BASE_URL/js/modern-portfolio.js" > /dev/null
+          curl -sf -H "$PROBE_HEADER" "$BASE_URL/js/modern-portfolio.js" > /dev/null
           echo "✅ JS OK"
           
           # Test 4: Contact API (validation test)
           echo "📧 Testing contact API validation..."
           CONTACT_RESPONSE=$(curl -s -X POST "$BASE_URL/api/contact" \
+            -H "$PROBE_HEADER" \
             -H "Content-Type: application/json" \
             -d '{}')
           echo "Contact response: $CONTACT_RESPONSE"
@@ -771,7 +828,7 @@ jobs:
           
           # Test 5: Profile subdomain
           echo "🌐 Testing profile subdomain..."
-          PROFILE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://profile.${{ env.DOMAIN_NAME }}/" || echo "000")
+          PROFILE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "$PROBE_HEADER" "https://profile.${{ env.DOMAIN_NAME }}/" || echo "000")
           if [ "$PROFILE_STATUS" = "200" ]; then
             echo "✅ Profile subdomain OK (Status: $PROFILE_STATUS)"
           else
@@ -780,7 +837,7 @@ jobs:
           
           # Test 6: Response time
           echo "⏱️ Testing response time..."
-          TIME=$(curl -s -o /dev/null -w "%{time_total}" "$BASE_URL/")
+          TIME=$(curl -s -o /dev/null -w "%{time_total}" -H "$PROBE_HEADER" "$BASE_URL/")
           echo "Response time: ${TIME}s"
           
           # Alert if response time > 3s

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -78,6 +78,13 @@ variable "acm_validation_value" {
   default     = "_a21d0ea08f7f5d4ec86278a9b3b41242.jkddzztszm.acm-validations.aws."
 }
 
+variable "ci_probe_secret" {
+  description = "Shared secret sent in the x-ci-probe header by CI health/smoke checks. Requests carrying this value skip Cloudflare WAF/bot products so CI runner IPs are not falsely blocked. Leave empty to disable the bypass rule."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # ==================== SSL/TLS Settings ====================
 
 # Set SSL mode to Full (Cloudflare connects to origin via HTTPS)
@@ -223,6 +230,52 @@ resource "cloudflare_record" "microsoft_domain_verification" {
   ttl     = 3600
   proxied = false
   comment = "Microsoft Entra ID domain verification for ankitraj.cloud"
+}
+
+# ==================== WAF: CI Probe Bypass ====================
+
+# Allow the GitHub Actions health/smoke probe past Cloudflare bot management
+# and managed WAF rules. CI runners share datacenter IP ranges that Cloudflare
+# bot protection challenges or blocks (HTTP 403), producing false-negative
+# smoke tests even when the edge is healthy. The probe sends a secret header;
+# this rule skips security products only for requests carrying the correct
+# secret, so genuine edge errors (5xx / 52x / connection failures) are still
+# caught by the pipeline. Count-gated so an empty secret disables the rule.
+resource "cloudflare_ruleset" "ci_probe_bypass" {
+  count = var.ci_probe_secret != "" ? 1 : 0
+
+  zone_id     = var.cloudflare_zone_id
+  name        = "CI probe WAF bypass"
+  description = "Skip WAF/bot products for the authenticated CI health probe"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
+
+  rules {
+    ref         = "ci_probe_skip"
+    description = "Skip security products when the CI probe secret header is present"
+    expression  = "(http.request.headers[\"x-ci-probe\"][0] eq \"${var.ci_probe_secret}\")"
+    action      = "skip"
+
+    action_parameters {
+      phases = [
+        "http_request_firewall_managed",
+        "http_request_sbfm",
+      ]
+      products = [
+        "bic",
+        "hot",
+        "rateLimit",
+        "securityLevel",
+        "uaBlock",
+        "waf",
+        "zoneLockdown",
+      ]
+    }
+
+    logging {
+      enabled = true
+    }
+  }
 }
 
 # Outputs

--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -252,23 +252,20 @@ resource "cloudflare_ruleset" "ci_probe_bypass" {
 
   rules {
     ref         = "ci_probe_skip"
-    description = "Skip security products when the CI probe secret header is present"
-    expression  = "(http.request.headers[\"x-ci-probe\"][0] eq \"${var.ci_probe_secret}\")"
+    description = "Skip free-tier security products for the CI probe on /health only"
+    expression  = "(http.request.uri.path eq \"/health\" and http.request.headers[\"x-ci-probe\"][0] eq \"${var.ci_probe_secret}\")"
     action      = "skip"
 
+    # Free-tier note: Bot Fight Mode (basic) cannot be skipped by custom rules;
+    # only these products are honored on the free plan. Managed WAF, Super Bot
+    # Fight Mode (http_request_sbfm), Zone Lockdown and Rate Limiting are Pro+
+    # and are intentionally omitted.
     action_parameters {
-      phases = [
-        "http_request_firewall_managed",
-        "http_request_sbfm",
-      ]
       products = [
         "bic",
         "hot",
-        "rateLimit",
         "securityLevel",
         "uaBlock",
-        "waf",
-        "zoneLockdown",
       ]
     }
 

--- a/terraform/cloudflare/terraform.tfvars.example
+++ b/terraform/cloudflare/terraform.tfvars.example
@@ -18,3 +18,10 @@ api_gateway_domain = "jmgjkrpp65.execute-api.eu-north-1.amazonaws.com"
 # ACM Certificate Validation (already configured)
 acm_validation_name  = "_fda1caf491ef2ac8c3dc323852e4243d"
 acm_validation_value = "_a21d0ea08f7f5d4ec86278a9b3b41242.jkddzztszm.acm-validations.aws."
+
+# CI probe secret (shared with the GitHub Actions secret CF_PROBE_SECRET).
+# CI sends this value in the "x-ci-probe" header so the health/smoke checks can
+# pass Cloudflare bot management instead of getting a false-negative 403.
+# Generate a random value (e.g. openssl rand -hex 24) and keep it secret.
+# Leave empty to disable the WAF bypass rule.
+ci_probe_secret = "YOUR_CI_PROBE_SECRET"


### PR DESCRIPTION
## Summary

Fixes false-negative CI failures where GitHub runner IPs were 403'd at the Cloudflare edge on the public domain health check, even though the edge and origin were healthy.

## Changes

- **Origin-gated health check**: CI verifies the Lambda origin directly (which it controls) and treats the public Cloudflare path as best-effort. 200 = healthy; 403/429/503 = edge up but filtering the runner IP (warn only, origin already verified); 000/5xx = real edge failure (exit 1).
- **Terraform (Cloudflare, free-tier aware)**: Add a count-gated cloudflare_ruleset.ci_probe_bypass (v4 block syntax), path-scoped to /health, that skips only free-plan security products (bic, hot, securityLevel, uaBlock) for requests carrying a secret x-ci-probe header. Empty secret disables the rule.
- **New variable** ci_probe_secret (sensitive) + tfvars example.
- **CI/CD workflow**: Wire CF_PROBE_SECRET into the Cloudflare plan/apply steps and send the x-ci-probe header on the health check and all smoke-test curls.

## Free-tier notes

- Managed WAF, Super Bot Fight Mode, Zone Lockdown and Rate Limiting are Pro+ and are intentionally omitted from the skip list (they would be no-ops on free).
- Basic Bot Fight Mode cannot be bypassed via custom rules on free tier; the origin-gated check is the real safeguard there.

## Security

- Bypass is path-scoped to /health and gated by a sensitive shared secret stored as the CF_PROBE_SECRET GitHub Actions secret.
- The WAF rule is managed entirely in Terraform; no manual Cloudflare dashboard changes.