### PR TITLE
fix(ci): gate Cloudflare CI probe ruleset behind opt-in flag

### DIFF
--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -85,6 +85,12 @@ variable "ci_probe_secret" {
   default     = ""
 }
 
+variable "enable_ci_probe_ruleset" {
+  description = "Create the CI probe WAF bypass ruleset. Requires the Cloudflare API token to have the Zone > Firewall Services > Edit (rulesets) permission. Leave false when the token only has DNS edit scope; the origin-gated CI health check works without this rule."
+  type        = bool
+  default     = false
+}
+
 # ==================== SSL/TLS Settings ====================
 
 # Set SSL mode to Full (Cloudflare connects to origin via HTTPS)
@@ -240,9 +246,11 @@ resource "cloudflare_record" "microsoft_domain_verification" {
 # smoke tests even when the edge is healthy. The probe sends a secret header;
 # this rule skips security products only for requests carrying the correct
 # secret, so genuine edge errors (5xx / 52x / connection failures) are still
-# caught by the pipeline. Count-gated so an empty secret disables the rule.
+# caught by the pipeline. Opt-in: requires both a secret and a token granted
+# the Zone > Firewall Services > Edit permission, otherwise the apply fails
+# with Cloudflare Authentication error (10000).
 resource "cloudflare_ruleset" "ci_probe_bypass" {
-  count = var.ci_probe_secret != "" ? 1 : 0
+  count = var.enable_ci_probe_ruleset && var.ci_probe_secret != "" ? 1 : 0
 
   zone_id     = var.cloudflare_zone_id
   name        = "CI probe WAF bypass"

--- a/terraform/cloudflare/terraform.tfvars.example
+++ b/terraform/cloudflare/terraform.tfvars.example
@@ -25,3 +25,10 @@ acm_validation_value = "_a21d0ea08f7f5d4ec86278a9b3b41242.jkddzztszm.acm-validat
 # Generate a random value (e.g. openssl rand -hex 24) and keep it secret.
 # Leave empty to disable the WAF bypass rule.
 ci_probe_secret = "YOUR_CI_PROBE_SECRET"
+
+# Opt-in toggle for the CI probe WAF bypass ruleset. Keep false unless the
+# Cloudflare API token has the "Zone > Firewall Services > Edit" (rulesets)
+# permission; otherwise the apply fails with Authentication error (10000).
+# The origin-gated CI health check works without this rule, so leaving it off
+# is the safe default.
+enable_ci_probe_ruleset = false


### PR DESCRIPTION
## Why

The pipeline on `main` is red. The squash-merge of #56 dropped the opt-in gate, so CI still tries to create `cloudflare_ruleset.ci_probe_bypass`. The CI Cloudflare API token only has DNS edit scope (no `Zone > Firewall Services > Edit`), so the apply fails with **Authentication error (10000)**, which triggers a Lambda rollback and fails the Deploy job.

## What

- Add `enable_ci_probe_ruleset` variable (default `false`) and AND it into the resource `count`, so CI no longer attempts to create the ruleset.
- Document the flag in `terraform.tfvars.example`.

The origin-gated post-deploy health check remains the dependable safeguard, so security coverage is unchanged.

## Re-enabling later

Grant the CI token the `Zone > Firewall Services > Edit` (rulesets) permission, then set `enable_ci_probe_ruleset = true`.

## Validation

- `terraform fmt` + `terraform validate` => Success! The configuration is valid.