### PR TITLE
fix(oidc): authorize GitHub environment subject for deploy role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ dist
 .pnp.*
 .DS_Store
 modernise.js
+
+# Accidentally nested git repo (not a submodule)
+restlessankyyy/

--- a/terraform/github-oidc/variables.tf
+++ b/terraform/github-oidc/variables.tf
@@ -21,13 +21,16 @@ variable "role_name" {
 variable "subject_claims" {
   description = <<-EOT
     Allowed GitHub OIDC `sub` claims that may assume the deploy role.
-    Defaults to the main branch and any pull request from this repo. Tighten
-    or widen as needed (for example, add an environment claim).
+    Covers the main branch, pull requests, and the deployment environments
+    (jobs that target a GitHub Environment get an `environment:` sub claim
+    instead of a `ref:` one). Tighten or widen as needed.
   EOT
   type        = list(string)
   default = [
     "repo:restlessankyyy/my-portfolio-app:ref:refs/heads/main",
     "repo:restlessankyyy/my-portfolio-app:pull_request",
+    "repo:restlessankyyy/my-portfolio-app:environment:production",
+    "repo:restlessankyyy/my-portfolio-app:environment:staging",
   ]
 }
 


### PR DESCRIPTION
## Problem

The `🚀 Deploy` job failed on the post-merge `main` run with:

```
Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

## Root cause

The deploy job targets the `production` GitHub Environment. When a job references an Environment, GitHub sets the OIDC token `sub` claim to:

```
repo:restlessankyyy/my-portfolio-app:environment:production
```

rather than `...:ref:refs/heads/main`. The IAM role trust policy only allowed the `main` ref and `pull_request` subjects, so the assume was denied. (terraform-validate has no environment, so it passed on PRs via the `pull_request` subject.)

## Fix

Add the `environment:production` and `environment:staging` subjects to the trust policy's allowed `sub` claims. The change has already been applied to the live role via `terraform apply` on the `terraform/github-oidc` bootstrap module; this PR keeps the IaC in sync.

## Verification

- `terraform validate` passes
- `terraform apply` applied cleanly (1 changed)
- Re-running the failed deploy now authorizes