### PR TITLE
fix(oidc): grant deploy role S3 config perms; fail fast on plan error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -279,11 +279,20 @@ jobs:
       - name: 📊 Terraform Plan
         id: plan
         run: |
+          set +e
           terraform plan -no-color -input=false -out=tfplan \
             -detailed-exitcode 2>&1 | tee plan.txt
-          echo "exitcode=$?" >> $GITHUB_OUTPUT
+          code=${PIPESTATUS[0]}
+          echo "exitcode=$code" >> $GITHUB_OUTPUT
+          # detailed-exitcode: 0 = no changes, 2 = changes present, 1 = error.
+          # Fail fast on a genuine planning error so an incomplete plan is never
+          # uploaded as an artifact and applied by the deploy job.
+          if [ "$code" -eq 1 ]; then
+            echo "::error::Terraform plan failed (exit code 1); not uploading an incomplete plan."
+            exit 1
+          fi
+          exit 0
         working-directory: terraform
-        continue-on-error: true
         env:
           TF_VAR_aws_region: ${{ env.AWS_REGION }}
 

--- a/terraform/github-oidc/main.tf
+++ b/terraform/github-oidc/main.tf
@@ -220,6 +220,17 @@ data "aws_iam_policy_document" "deploy" {
       "s3:GetObject",
       "s3:PutObject",
       "s3:DeleteObject",
+      # The aws_s3_bucket provider refreshes these sub-configurations on every
+      # plan. Their IAM action names do not match the s3:GetBucket*/s3:PutBucket*
+      # wildcards, so they must be granted explicitly.
+      "s3:GetLifecycleConfiguration",
+      "s3:PutLifecycleConfiguration",
+      "s3:GetEncryptionConfiguration",
+      "s3:PutEncryptionConfiguration",
+      "s3:GetReplicationConfiguration",
+      "s3:PutReplicationConfiguration",
+      "s3:GetAccelerateConfiguration",
+      "s3:PutAccelerateConfiguration",
     ]
     resources = [
       "arn:aws:s3:::${var.project_name}-*",


### PR DESCRIPTION
## Problem

The first keyless OIDC deploy on main (run 27465494696) reached the deploy job (OIDC auth + submodule cleanup fixes from #66 worked), but **Terraform plan failed** with:

```
AccessDenied: not authorized to perform: s3:GetLifecycleConfiguration
on arn:aws:s3:::portfolio-ankit-assets-7ette088
```

The error was swallowed (the plan step's `| tee` masked terraform's exit code and the step was `continue-on-error`), so an **incomplete plan** was uploaded and the deploy job then failed with `Cannot apply incomplete plan`.

## Root cause

The OIDC deploy role's `ProjectAssetBuckets` policy used `s3:GetBucket*` / `s3:PutBucket*` wildcards. Several S3 sub-configurations the `aws_s3_bucket` provider reads on **every plan** use IAM action names that do NOT match those wildcards:
- `s3:GetLifecycleConfiguration` / `s3:PutLifecycleConfiguration`
- `s3:GetEncryptionConfiguration` / `s3:PutEncryptionConfiguration`
- `s3:GetReplicationConfiguration` / `s3:PutReplicationConfiguration`
- `s3:GetAccelerateConfiguration` / `s3:PutAccelerateConfiguration`

## Fix

1. **IAM**: Added the explicit S3 config actions to the deploy role policy (already `terraform apply`-ed live: `0 added, 1 changed, 0 destroyed`).
2. **Workflow hardening**: The Terraform Plan step now captures terraform's real exit code via `PIPESTATUS` and fails fast on exit code 1, so a broken plan is never uploaded and applied.

## Validation

- `terraform fmt -recursive` + `terraform validate` pass.
- IAM change applied live to `portfolio-ankit-github-deploy`.