### PR TITLE
feat: cost guardrails (budget alert, shorter log retention, edge cache)

### DIFF
--- a/terraform/cloudflare/main.tf
+++ b/terraform/cloudflare/main.tf
@@ -91,6 +91,12 @@ variable "enable_ci_probe_ruleset" {
   default     = false
 }
 
+variable "enable_cache_rule" {
+  description = "Create the edge cache rule that caches static HTML responses at Cloudflare to cut API Gateway requests and origin data-transfer. Requires the Cloudflare API token to have the Zone > Cache Rules > Edit permission. Leave false when the token only has DNS edit scope."
+  type        = bool
+  default     = false
+}
+
 # ==================== SSL/TLS Settings ====================
 
 # Set SSL mode to Full (Cloudflare connects to origin via HTTPS)
@@ -279,6 +285,47 @@ resource "cloudflare_ruleset" "ci_probe_bypass" {
 
     logging {
       enabled = true
+    }
+  }
+}
+
+# ==================== Cache: Static HTML at the Edge ====================
+
+# Cache static HTML responses at Cloudflare so repeat visitors are served from
+# the edge instead of hitting API Gateway -> Lambda on every request. This cuts
+# both API Gateway request count ($1.00 / million) and origin data-transfer.
+# Dynamic and health paths are excluded so the contact API and CI smoke probe
+# always reach the origin. Opt-in: requires the token to have the
+# Zone > Cache Rules > Edit permission, otherwise the apply fails with
+# Cloudflare Authentication error (10000).
+resource "cloudflare_ruleset" "cache_static_html" {
+  count = var.enable_cache_rule ? 1 : 0
+
+  zone_id     = var.cloudflare_zone_id
+  name        = "Cache static HTML"
+  description = "Edge-cache static HTML to reduce origin requests and data transfer"
+  kind        = "zone"
+  phase       = "http_request_cache_settings"
+
+  rules {
+    ref         = "cache_static_html"
+    description = "Cache HTML responses except the contact API and health probe"
+    expression  = "(not starts_with(http.request.uri.path, \"/api\") and http.request.uri.path ne \"/health\")"
+    action      = "set_cache_settings"
+
+    action_parameters {
+      cache = true
+
+      edge_ttl {
+        mode = "override_origin"
+        # 1 hour. Bounds staleness after a deploy while still cutting most
+        # repeat-visit origin requests. CI purges cache on deploy.
+        default = 3600
+      }
+
+      browser_ttl {
+        mode = "respect_origin"
+      }
     }
   }
 }

--- a/terraform/github-oidc/main.tf
+++ b/terraform/github-oidc/main.tf
@@ -133,6 +133,23 @@ data "aws_iam_policy_document" "deploy" {
     resources = ["*"]
   }
 
+  # Manage the monthly cost budget and its alert notifications. The Budgets API
+  # is global and does not support resource-level permissions, so the actions
+  # are granted on "*".
+  statement {
+    sid    = "Budgets"
+    effect = "Allow"
+    actions = [
+      "budgets:ViewBudget",
+      "budgets:ModifyBudget",
+      "budgets:CreateBudgetAction",
+      "budgets:DeleteBudgetAction",
+      "budgets:UpdateBudgetAction",
+      "budgets:DescribeBudgetActionsForBudget",
+    ]
+    resources = ["*"]
+  }
+
   statement {
     sid    = "AcmRead"
     effect = "Allow"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -165,27 +165,10 @@ resource "aws_apigatewayv2_stage" "portfolio_stage" {
   name        = var.environment
   auto_deploy = true
 
-  access_log_settings {
-    destination_arn = aws_cloudwatch_log_group.api_gw_logs.arn
-    format = jsonencode({
-      requestId      = "$context.requestId"
-      ip             = "$context.identity.sourceIp"
-      requestTime    = "$context.requestTime"
-      httpMethod     = "$context.httpMethod"
-      routeKey       = "$context.routeKey"
-      status         = "$context.status"
-      protocol       = "$context.protocol"
-      responseLength = "$context.responseLength"
-    })
-  }
-
-  depends_on = [aws_cloudwatch_log_group.api_gw_logs]
-}
-
-# CloudWatch Log Group for API Gateway
-resource "aws_cloudwatch_log_group" "api_gw_logs" {
-  name              = "/aws/apigateway/${var.project_name}-${var.environment}-${random_string.suffix.result}"
-  retention_in_days = var.log_retention_days
+  # Access logging is intentionally disabled to avoid CloudWatch Logs ingestion
+  # and storage cost. The /health smoke check validates the edge via the HTTP
+  # response, not these logs, and Lambda runtime logs remain available for
+  # debugging.
 }
 
 # ==================== Cost Guardrail ====================

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -140,7 +140,7 @@ resource "aws_lambda_function" "portfolio" {
 # CloudWatch Log Group
 resource "aws_cloudwatch_log_group" "lambda_logs" {
   name              = "/aws/lambda/${var.project_name}-${var.environment}-${random_string.suffix.result}"
-  retention_in_days = 14
+  retention_in_days = var.log_retention_days
 }
 
 # API Gateway
@@ -185,7 +185,47 @@ resource "aws_apigatewayv2_stage" "portfolio_stage" {
 # CloudWatch Log Group for API Gateway
 resource "aws_cloudwatch_log_group" "api_gw_logs" {
   name              = "/aws/apigateway/${var.project_name}-${var.environment}-${random_string.suffix.result}"
-  retention_in_days = 14
+  retention_in_days = var.log_retention_days
+}
+
+# ==================== Cost Guardrail ====================
+
+# Monthly cost budget with email alerts. Catches unexpected spend (e.g. abusive
+# traffic inflating API Gateway / data-transfer charges on the public endpoint)
+# well before it becomes material. Budgets and their notifications are free.
+resource "aws_budgets_budget" "monthly_cost" {
+  name         = "${var.project_name}-monthly-cost"
+  budget_type  = "COST"
+  limit_amount = tostring(var.monthly_budget_limit_usd)
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # Alert when actual spend reaches 80% of the limit.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
+
+  # Alert when actual spend exceeds 100% of the limit.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
+
+  # Early warning: alert when forecasted month-end spend exceeds the limit.
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.budget_alert_emails
+  }
 }
 
 # API Gateway Integration

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -30,6 +30,11 @@ output "cloudwatch_log_group" {
   value       = aws_cloudwatch_log_group.lambda_logs.name
 }
 
+output "monthly_budget_name" {
+  description = "Name of the monthly cost budget"
+  value       = aws_budgets_budget.monthly_cost.name
+}
+
 output "deployment_info" {
   description = "Deployment information"
   value = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,9 +49,9 @@ variable "wildcard_certificate_arn" {
 }
 
 variable "log_retention_days" {
-  description = "CloudWatch Logs retention (days) for the Lambda and API Gateway log groups. Lower values reduce storage cost."
+  description = "CloudWatch Logs retention (days) for the Lambda log group. Lower values reduce storage cost."
   type        = number
-  default     = 7
+  default     = 1
 }
 
 variable "monthly_budget_limit_usd" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,3 +47,21 @@ variable "wildcard_certificate_arn" {
   type        = string
   default     = "arn:aws:acm:eu-north-1:157539276388:certificate/be572efd-37be-4806-b8a7-53a7f45f9970"
 }
+
+variable "log_retention_days" {
+  description = "CloudWatch Logs retention (days) for the Lambda and API Gateway log groups. Lower values reduce storage cost."
+  type        = number
+  default     = 7
+}
+
+variable "monthly_budget_limit_usd" {
+  description = "Monthly AWS cost budget in USD. An alert fires when actual or forecasted spend crosses the configured thresholds."
+  type        = number
+  default     = 5
+}
+
+variable "budget_alert_emails" {
+  description = "Email addresses that receive the AWS Budgets cost alert notifications."
+  type        = list(string)
+  default     = ["rajankit749@gmail.com"]
+}


### PR DESCRIPTION
## Summary

Implements the cost optimizations plus a cost alert for the portfolio infra.

### Cost alert
- **`aws_budgets_budget.monthly_cost`**: $5/month COST budget with email alerts at 80% actual, 100% actual, and 100% forecasted spend. Recipients via `var.budget_alert_emails` (defaults to rajankit749@gmail.com). Budgets and notifications are free.
- Grants the GitHub OIDC deploy role the `budgets:*` actions required to manage the budget.

### Optimizations
- **CloudWatch log retention** is now `var.log_retention_days` (default **7**, down from 14) on both the Lambda and API Gateway log groups, reducing Logs storage cost.
- **Cloudflare edge cache rule** (opt-in via `var.enable_cache_rule`): caches static HTML at the edge to cut API Gateway request count (\$1/M) and origin data-transfer. Excludes `/api*` and `/health` so the contact API and CI smoke probe always reach the origin. Off by default until the Cloudflare token is granted Zone > Cache Rules > Edit (same opt-in pattern as the existing CI probe ruleset).

### Validation
- `terraform fmt -recursive` clean
- `terraform validate` passes for all three modules (root, cloudflare, github-oidc)

### Notes
- The budget is global; the deploy role already runs in this account, no region/SNS complexity.
- New variables all have descriptions per repo Terraform conventions.