### PR TITLE
fix(security): harden server routes + remove stale Trivy/Checkov refs

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -33,7 +33,7 @@ This repository implements an **enterprise-grade CI/CD pipeline** using GitHub A
 | Stage | Job | Description |
 |-------|-----|-------------|
 | 1 | `code-quality` | ESLint, Prettier, npm audit |
-| 2 | `security-scan` | GitLeaks, Trivy vulnerability scanning |
+| 2 | `security-scan` | Dependency Review (GitHub Advisory DB) + native Secret Scanning |
 | 3 | `test` | Unit tests, integration tests |
 | 4 | `terraform-validate` | IaC validation, format check, plan |
 | 5 | `build` | Lambda package creation, artifact upload |
@@ -47,16 +47,15 @@ This repository implements an **enterprise-grade CI/CD pipeline** using GitHub A
 - Pull requests to `main`
 - Manual workflow dispatch
 
-### 2. Security Scan (`security-scan.yml`)
+### 2. Security Scanning (GitHub-native)
 
-**Scheduled weekly security scanning:**
+**Continuous, first-party security coverage:**
 
-- 📦 NPM dependency audit
-- 🔐 Secret detection (GitLeaks)
-- 🛡️ Trivy vulnerability scanner
-- 🏗️ Checkov IaC security scan
-
-**Schedule:** Every Monday at 9:00 AM UTC
+- 📦 NPM dependency audit (`code-quality` job)
+- 🔎 Dependency Review on PRs (GitHub Advisory Database)
+- 🔐 Secret Scanning + Push Protection (repo Settings)
+- 🤖 Dependabot alerts + updates
+- 🧠 CodeQL SAST (`codeql.yml`)
 
 ### 3. Dependency Update (`dependency-update.yml`)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,7 +80,7 @@ lambda.js                → AWS Lambda handler (@vendia/serverless-express)
 
 - Run `npm run validate` before committing (lint + format check + tests)
 - ESLint for JS, Prettier for formatting
-- Security: CodeQL, Dependabot, npm audit, Gitleaks, Trivy all run in CI
+- Security (all GitHub-native): CodeQL, Dependabot, npm audit, Dependency Review, Secret Scanning + Push Protection
 
 ### Git
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -60,7 +60,7 @@ ci: add CodeQL security scanning
 ## Security
 
 - Never commit secrets or API keys
-- Gitleaks runs in CI to catch leaked secrets
+- GitHub Secret Scanning + Push Protection catch leaked secrets
 - CodeQL + npm audit check for vulnerabilities
 - Dependabot keeps dependencies updated
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Premium cinematic portfolio website for **Ankit Raj**, Lead Solution Architect a
 | **DNS/CDN** | Cloudflare (DNS, SSL, Page Rules) |
 | **IaC** | Terraform (AWS + Cloudflare) |
 | **CI/CD** | GitHub Actions (7 workflows), keyless AWS via OIDC |
-| **Security** | CodeQL, Dependabot, npm audit, Gitleaks, Trivy |
+| **Security** | CodeQL, Dependabot, npm audit, Dependency Review, Secret Scanning |
 
 ## 📁 Project Structure
 
@@ -261,8 +261,8 @@ npm test
 - **CodeQL** static analysis for JavaScript vulnerabilities
 - **Dependabot** automated dependency updates
 - **npm audit** CI check for known CVEs (0 vulnerabilities)
-- **Gitleaks** secret detection in commits
-- **Trivy** vulnerability scanning
+- **Dependency Review** blocks vulnerable dependencies on PRs (GitHub Advisory DB)
+- **Secret Scanning + Push Protection** native secret detection
 - **OIDC** keyless AWS deploys (no static credentials in CI)
 - **npm overrides** pinned `fast-xml-parser >=5.3.8` to patch CVEs
 - **IAM** least-privilege roles for Lambda and deploy

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -6,7 +6,6 @@
 |----------|---------|---------|
 | `ci-cd.yml` | Push to `main`, PRs to `main` | Full pipeline: lint → scan → test → build → deploy → smoke test |
 | `codeql.yml` | Push/PR to `main` + weekly | CodeQL static analysis for JavaScript |
-| `security-scan.yml` | Weekly + manual | Gitleaks (secrets) + Trivy (vulnerabilities) |
 | `security-audit.yml` | Push/PR (package changes) | npm audit + outdated packages |
 | `resume-pdf.yml` | Push (`resume-aws-sa.html`) + manual | Auto-regenerate Profile.pdf |
 | `resume-nordic-pdf.yml` | Push (`resume-photo.html`) + manual | Auto-regenerate Profile-Nordic.pdf |
@@ -25,7 +24,7 @@ flowchart TD
     PR[Pull Request to main]:::trigger --> CQ
     PUSH[Push to main]:::trigger --> CQ
 
-    CQ[1. Code Quality<br/>ESLint, Prettier, npm audit] --> SS[2. Security Scan<br/>Gitleaks, Trivy]
+    CQ[1. Code Quality<br/>ESLint, Prettier, npm audit] --> SS[2. Security Scan<br/>Dependency Review, Secret Scanning]
     SS --> TST[3. Tests<br/>8 unit tests]
     TST --> TFV[4. Terraform Validate<br/>fmt, init, validate, plan]
 
@@ -49,7 +48,7 @@ flowchart TD
 | Stage | Job | What it does |
 |-------|-----|-------------|
 | 1 | `code-quality` | ESLint, Prettier, npm audit |
-| 2 | `security-scan` | Gitleaks, Trivy |
+| 2 | `security-scan` | Dependency Review (GitHub Advisory DB) + Secret Scanning |
 | 3 | `test` | Unit tests (8 cases) |
 | 4 | `terraform-validate` | IaC format check + plan |
 | 5 | `build` | Lambda package creation |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,7 +52,7 @@ ci: add CodeQL security scanning
 ## Security
 
 - Never commit secrets or API keys
-- Gitleaks runs in CI to catch leaked secrets
+- GitHub Secret Scanning + Push Protection catch leaked secrets
 - CodeQL + npm audit check for vulnerabilities
 
 ## Reporting Bugs

--- a/server.js
+++ b/server.js
@@ -4,17 +4,30 @@ const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
 const app = express();
 
+// Behind API Gateway / Lambda, trust the first proxy hop so the rate
+// limiter keys on the real client IP (X-Forwarded-For) rather than the proxy.
+app.set('trust proxy', 1);
+
 // Security headers
 app.use(helmet());
 
 // Parse JSON bodies with size limit to prevent large-payload DoS
 app.use(express.json({ limit: '10kb' }));
 
-// Root domain landing page — ankitraj.cloud / www.ankitraj.cloud
+// General rate limit for page/file-serving routes to bound abuse of the
+// filesystem-backed handlers (landing page + SPA catch-all).
+const pageLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 1000,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// Root domain landing page: ankitraj.cloud / www.ankitraj.cloud
 // profile.ankitraj.cloud serves the full portfolio via static + SPA catch-all below
 const ROOT_HOSTS = ['ankitraj.cloud', 'www.ankitraj.cloud'];
 
-app.get('/', (req, res, next) => {
+app.get('/', pageLimiter, (req, res, next) => {
   const host = (req.hostname || '').split(':')[0];
   if (ROOT_HOSTS.includes(host)) {
     return res.sendFile(path.join(__dirname, 'public', 'landing.html'));
@@ -62,9 +75,10 @@ app.post('/api/contact', contactLimiter, async (req, res) => {
       });
     }
 
-    // Email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    // Email validation. Length guard + non-backtracking regex (domain labels
+    // exclude dots so quantifiers cannot overlap) to avoid polynomial ReDoS.
+    const emailRegex = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
+    if (typeof email !== 'string' || email.length > 254 || !emailRegex.test(email)) {
       return res.status(400).json({ 
         success: false, 
         error: 'Invalid email address' 
@@ -183,7 +197,7 @@ app.post('/api/contact', contactLimiter, async (req, res) => {
 });
 
 // Catch all handler: send back index.html for SPA routing
-app.get('*', (req, res) => {
+app.get('*', pageLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
## What

Resolves the live CodeQL findings on `server.js` and clears the stale Trivy/Checkov noise in the Security tab.

### Code (server.js)
- **Rate limiting**: added a general `pageLimiter` (1000 req / 15 min / IP) on the `/` landing route and the SPA catch-all, so the filesystem-backed handlers are bounded. Fixes CodeQL `js/missing-rate-limiting` (lines 17, 186).
- **ReDoS**: replaced the email regex with a non-backtracking pattern (`^[^\\s@]+@[^\\s@.]+(?:\\.[^\\s@.]+)+$`) plus a 254-char length guard. Fixes CodeQL `js/polynomial-redos` (line 67).
- **trust proxy**: set so the limiter keys on the real client IP behind API Gateway / Lambda.

### Stale scanner cleanup
- Deleted all 165 stale Trivy + Checkov code-scanning analyses (157 Trivy + 8 Checkov). Those tools were already removed from CI; the alerts were leftovers that GitHub never auto-closes. Security tab now shows only the 3 CodeQL alerts (which this PR fixes).
- Updated README / CICD / Contributing docs: CI security scanning is now fully GitHub-native (CodeQL, Dependabot, npm audit, Dependency Review, Secret Scanning + Push Protection). Trivy, Checkov, and Gitleaks references removed.

## Validation
- `npm test` -> 8 passed
- `npx eslint server.js` -> clean
- Email regex spot-checked against valid + malformed inputs
- `npm audit` -> 0 vulnerabilities