### PR TITLE
fix(oidc): grant deploy role log-delivery + budgets perms

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -317,7 +317,11 @@ jobs:
           TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_custom_domain_target: "d-hctzaliyt6.execute-api.eu-north-1.amazonaws.com"
-          TF_VAR_profile_domain_target: ""
+          # Use the live profile custom-domain target (the AWS stack always
+          # provisions profile.ankitraj.cloud) so the plan preview matches what
+          # apply does. Passing "" here made count=0 and showed a phantom
+          # destroy of cloudflare_record.profile on every plan.
+          TF_VAR_profile_domain_target: "d-892wmteha9.execute-api.eu-north-1.amazonaws.com"
           TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
 
       - name: 📤 Upload Terraform Plan

--- a/terraform/github-oidc/main.tf
+++ b/terraform/github-oidc/main.tf
@@ -119,6 +119,16 @@ data "aws_iam_policy_document" "deploy" {
       "logs:TagResource",
       "logs:UntagResource",
       "logs:ListTagsForResource",
+      # Required by API Gateway v2 UpdateStage to set OR clear a stage's access
+      # log settings. AWS validates these even when logging is being disabled,
+      # so they are needed to remove logging from the existing prod stage.
+      "logs:CreateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:UpdateLogDelivery",
+      "logs:ListLogDeliveries",
+      "logs:PutResourcePolicy",
+      "logs:DescribeResourcePolicies",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Why

The prod deploy for #69 failed on two AccessDenied errors:

1. **API Gateway v2 UpdateStage** needs `logs:*LogDelivery` to clear the existing prod stage's access-log settings (the cost-guardrail change removed access logging, but AWS validates the log-delivery permission even when disabling).
2. **aws_budgets_budget** needs `budgets:ModifyBudget`. The Budgets statement was already in the policy document but the bootstrap `github-oidc` module had never been re-applied, so the live role lacked it.

## What

- Add the log-delivery actions (`CreateLogDelivery`, `DeleteLogDelivery`, `GetLogDelivery`, `UpdateLogDelivery`, `ListLogDeliveries`, `PutResourcePolicy`, `DescribeResourcePolicies`) to the `CloudWatchLogs` statement.

## Applied

The `github-oidc` bootstrap module was applied with the admin identity (`terraform apply` -> 1 changed), so the live `portfolio-ankit-github-deploy` role already carries both the log-delivery and budgets permissions. This PR is the source-of-truth update. The main deploy has been re-run.