### PR TITLE
fix(infra): manage API Gateway access-log group to stop deploy 404s

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -317,7 +317,11 @@ jobs:
           TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_custom_domain_target: "d-hctzaliyt6.execute-api.eu-north-1.amazonaws.com"
-          TF_VAR_profile_domain_target: ""
+          # Use the live profile custom-domain target (the AWS stack always
+          # provisions profile.ankitraj.cloud) so the plan preview matches what
+          # apply does. Passing "" here made count=0 and showed a phantom
+          # destroy of cloudflare_record.profile on every plan.
+          TF_VAR_profile_domain_target: "d-892wmteha9.execute-api.eu-north-1.amazonaws.com"
           TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
 
       - name: 📤 Upload Terraform Plan

--- a/terraform/github-oidc/main.tf
+++ b/terraform/github-oidc/main.tf
@@ -156,6 +156,11 @@ data "aws_iam_policy_document" "deploy" {
       "budgets:DeleteBudgetAction",
       "budgets:UpdateBudgetAction",
       "budgets:DescribeBudgetActionsForBudget",
+      # The provider applies default_tags to the budget, so creating or updating
+      # it calls TagResource/UntagResource on the budget ARN.
+      "budgets:TagResource",
+      "budgets:UntagResource",
+      "budgets:ListTagsForResource",
     ]
     resources = ["*"]
   }

--- a/terraform/github-oidc/main.tf
+++ b/terraform/github-oidc/main.tf
@@ -119,6 +119,16 @@ data "aws_iam_policy_document" "deploy" {
       "logs:TagResource",
       "logs:UntagResource",
       "logs:ListTagsForResource",
+      # Required by API Gateway v2 UpdateStage to set OR clear a stage's access
+      # log settings. AWS validates these even when logging is being disabled,
+      # so they are needed to remove logging from the existing prod stage.
+      "logs:CreateLogDelivery",
+      "logs:DeleteLogDelivery",
+      "logs:GetLogDelivery",
+      "logs:UpdateLogDelivery",
+      "logs:ListLogDeliveries",
+      "logs:PutResourcePolicy",
+      "logs:DescribeResourcePolicies",
     ]
     resources = ["*"]
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -143,6 +143,22 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
   retention_in_days = var.log_retention_days
 }
 
+# CloudWatch Log Group for API Gateway access logs.
+#
+# API Gateway v2 does not support clearing access logging in place: an empty
+# AccessLogSettings is treated as "no change" and empty destination/format
+# values are rejected, so logging that was once enabled cannot be removed
+# without recreating the stage (which would cascade to the live custom-domain
+# mappings). Instead of disabling it, we keep access logging on but make the
+# destination Terraform-managed with the same short retention as the Lambda
+# logs. This bounds cost to a single day of ingestion (effectively zero at this
+# traffic level) and, critically, guarantees the log destination always exists
+# so stage updates never fail with LogDestinationNotFoundException.
+resource "aws_cloudwatch_log_group" "apigw_access_logs" {
+  name              = "/aws/apigateway/${var.project_name}-${var.environment}-${random_string.suffix.result}"
+  retention_in_days = var.log_retention_days
+}
+
 # API Gateway
 resource "aws_apigatewayv2_api" "portfolio_api" {
   name          = "${var.project_name}-api-${random_string.suffix.result}"
@@ -165,10 +181,25 @@ resource "aws_apigatewayv2_stage" "portfolio_stage" {
   name        = var.environment
   auto_deploy = true
 
-  # Access logging is intentionally disabled to avoid CloudWatch Logs ingestion
-  # and storage cost. The /health smoke check validates the edge via the HTTP
-  # response, not these logs, and Lambda runtime logs remain available for
-  # debugging.
+  # Access logging is intentionally kept minimal rather than disabled. API
+  # Gateway v2 cannot clear access logging in place once it has been enabled, so
+  # we point it at a Terraform-managed log group with one-day retention (see
+  # aws_cloudwatch_log_group.apigw_access_logs). This keeps ingestion cost
+  # negligible while ensuring the destination always exists, so stage updates
+  # never fail with LogDestinationNotFoundException.
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.apigw_access_logs.arn
+    format = jsonencode({
+      httpMethod     = "$context.httpMethod"
+      ip             = "$context.identity.sourceIp"
+      protocol       = "$context.protocol"
+      requestId      = "$context.requestId"
+      requestTime    = "$context.requestTime"
+      responseLength = "$context.responseLength"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+    })
+  }
 }
 
 # ==================== Cost Guardrail ====================


### PR DESCRIPTION
## Problem

The cost-guardrails work (#68) removed the API Gateway access-log group and dropped the stage's `access_log_settings` block, intending to disable access logging. But the live prod stage still had logging enabled pointing at the now-deleted group `/aws/apigateway/portfolio-ankit-prod-7ette088`. Two consequences:

1. **Deploys 404'd.** API Gateway re-validates the existing log destination on every `UpdateStage`, so any stage change failed with `LogDestinationNotFoundException`.
2. **Logging was never actually disabled.** The AWS provider treats an *absent* `access_log_settings` block as unmanaged, so Terraform left the live logging in place. API Gateway v2 also cannot clear logging in place: an empty `AccessLogSettings` is a no-op and empty destination/format values are rejected. The only way to truly disable it is to recreate the stage, which would cascade to the live `profile.ankitraj.cloud` custom-domain mapping (downtime + risk) for negligible savings.

## Fix

Make the access-log destination a first-class **managed** resource instead of fighting the API:

- Add `aws_cloudwatch_log_group.apigw_access_logs` with **one-day retention** (same as the Lambda logs).
- Wire the stage's `access_log_settings` to it (format matches the live format exactly, so no stage churn).

This bounds ingestion cost to a single day (effectively zero at this traffic) and **guarantees the destination always exists**, so `UpdateStage` never 404s again.

## Applied / converged

The existing live log group was **imported into remote state** and `terraform apply` converged it (only the provider `default_tags` were applied; retention already 1 day). A follow-up `terraform plan` reports **No changes**, so the next pipeline run is a clean no-op. The deploy role already carries `logs:TagResource`/`UntagResource`/`ListTagsForResource` (from #70/#71), so CI applies cleanly.