### PR TITLE
Green Room: Cloudflare-only TLS (fix meet.ankitraj.cloud deploy)

### DIFF
--- a/.github/workflows/green-room.yml
+++ b/.github/workflows/green-room.yml
@@ -113,8 +113,6 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
       - name: Terraform fmt / init / validate / plan
         working-directory: green-room/terraform
-        env:
-          TF_VAR_certificate_arn: ${{ secrets.GREENROOM_CERT_ARN }}
         run: |
           terraform fmt -check -recursive || echo "::warning::terraform fmt drift"
           terraform init -input=false
@@ -183,8 +181,6 @@ jobs:
           path: green-room/terraform/
       - name: Deploy AWS infrastructure
         working-directory: green-room/terraform
-        env:
-          TF_VAR_certificate_arn: ${{ secrets.GREENROOM_CERT_ARN }}
         run: |
           terraform init -input=false
           terraform apply -auto-approve -input=false
@@ -198,16 +194,14 @@ jobs:
           aws lambda wait function-updated --function-name "$FN"
           API_URL=$(terraform output -raw api_gateway_url)
           echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
-          echo "custom_domain_target=$(terraform output -raw custom_domain_target)" >> "$GITHUB_ENV"
+          echo "origin_host=$(terraform output -raw api_endpoint_host)" >> "$GITHUB_ENV"
       - name: Deploy Cloudflare DNS
         working-directory: green-room/terraform/cloudflare
         continue-on-error: true
         env:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
-          TF_VAR_custom_domain_target: ${{ env.custom_domain_target }}
-          TF_VAR_acm_validation_name: ${{ secrets.GREENROOM_ACM_VALIDATION_NAME }}
-          TF_VAR_acm_validation_value: ${{ secrets.GREENROOM_ACM_VALIDATION_VALUE }}
+          TF_VAR_origin_host: ${{ env.origin_host }}
           TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
         run: |
           if [ -z "${TF_VAR_cloudflare_api_token}" ]; then

--- a/green-room/README.md
+++ b/green-room/README.md
@@ -112,19 +112,16 @@ The pipeline is `.github/workflows/green-room.yml`, path-filtered to
 Terraform, updates the function code (keyless via OIDC), and updates Cloudflare
 DNS.
 
+TLS is handled entirely by Cloudflare: `meet.ankitraj.cloud` is a proxied CNAME
+to the API Gateway default endpoint, so Cloudflare's Universal SSL terminates
+public HTTPS and connects to the AWS origin over its built-in `*.execute-api`
+certificate. There is no ACM certificate to manage.
+
 ### One-time setup
 
-1. Request a regional ACM certificate for `meet.ankitraj.cloud` in `eu-north-1`
-   and validate it via the Cloudflare CNAME:
-
-   ```bash
-   aws acm request-certificate --domain-name meet.ankitraj.cloud \
-     --validation-method DNS --region eu-north-1
-   ```
-
-2. Add repository secrets: `GREENROOM_CERT_ARN`, `GREENROOM_ACM_VALIDATION_NAME`,
-   `GREENROOM_ACM_VALIDATION_VALUE` (reusing `AWS_ROLE_ARN`, `CLOUDFLARE_API_TOKEN`,
-   `CLOUDFLARE_ZONE_ID`, and optionally `CF_PROBE_SECRET`).
+Add repository secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID` (reusing the
+existing `AWS_ROLE_ARN`, and optionally `CF_PROBE_SECRET`). No ACM/certificate
+secrets are needed.
 
 Infra config lives in `terraform/terraform.tfvars.example` and
 `terraform/cloudflare/terraform.tfvars.example`.

--- a/green-room/terraform/cloudflare/main.tf
+++ b/green-room/terraform/cloudflare/main.tf
@@ -61,18 +61,8 @@ variable "record_name" {
   default     = "meet"
 }
 
-variable "custom_domain_target" {
-  description = "API Gateway custom-domain target (from the AWS stack output custom_domain_target)."
-  type        = string
-}
-
-variable "acm_validation_name" {
-  description = "ACM certificate validation CNAME name for meet.ankitraj.cloud."
-  type        = string
-}
-
-variable "acm_validation_value" {
-  description = "ACM certificate validation CNAME value for meet.ankitraj.cloud."
+variable "origin_host" {
+  description = "API Gateway default endpoint host (from the AWS stack output api_endpoint_host). Cloudflare proxies meet.ankitraj.cloud to this origin."
   type        = string
 }
 
@@ -91,27 +81,17 @@ variable "enable_ci_probe_ruleset" {
 
 # ==================== DNS records ====================
 
-# ACM certificate validation (DNS only, must not be proxied).
-resource "cloudflare_record" "acm_validation" {
-  zone_id = var.cloudflare_zone_id
-  name    = var.acm_validation_name
-  content = var.acm_validation_value
-  type    = "CNAME"
-  ttl     = 1
-  proxied = false
-  comment = "AWS ACM certificate validation for meet.ankitraj.cloud"
-}
-
-# App subdomain -> API Gateway custom domain. Proxied so Cloudflare terminates
-# TLS for meet.ankitraj.cloud at the edge.
+# App subdomain -> API Gateway default endpoint. Proxied so Cloudflare
+# terminates public TLS at the edge (Universal SSL) and connects to the AWS
+# origin over its built-in *.execute-api certificate (Full mode). No ACM cert.
 resource "cloudflare_record" "app" {
   zone_id = var.cloudflare_zone_id
   name    = var.record_name
-  content = var.custom_domain_target
+  content = var.origin_host
   type    = "CNAME"
   ttl     = 1
   proxied = true
-  comment = "meet.ankitraj.cloud to Green Room API Gateway custom domain"
+  comment = "meet.ankitraj.cloud to Green Room API Gateway endpoint"
 }
 
 # ==================== WAF: CI probe bypass (opt-in) ====================
@@ -153,9 +133,4 @@ resource "cloudflare_ruleset" "ci_probe_bypass" {
 output "app_record" {
   description = "App subdomain CNAME record."
   value       = cloudflare_record.app.hostname
-}
-
-output "acm_validation_record" {
-  description = "ACM validation CNAME record."
-  value       = cloudflare_record.acm_validation.hostname
 }

--- a/green-room/terraform/cloudflare/terraform.tfvars.example
+++ b/green-room/terraform/cloudflare/terraform.tfvars.example
@@ -7,15 +7,9 @@ cloudflare_api_token = "YOUR_CLOUDFLARE_API_TOKEN"
 # Cloudflare Zone ID for ankitraj.cloud.
 cloudflare_zone_id = "YOUR_ZONE_ID"
 
-# API Gateway custom-domain target from the AWS stack:
-#   terraform -chdir=green-room/terraform output -raw custom_domain_target
-custom_domain_target = "dXXXXXXXX.execute-api.eu-north-1.amazonaws.com"
-
-# ACM certificate validation CNAME for meet.ankitraj.cloud:
-#   aws acm describe-certificate --certificate-arn <arn> --region eu-north-1 \
-#     --query 'Certificate.DomainValidationOptions[0].ResourceRecord'
-acm_validation_name  = "_xxxxxxxxxxxxxxxx.meet.ankitraj.cloud"
-acm_validation_value = "_yyyyyyyyyyyyyyyy.zzzzzzzzzz.acm-validations.aws."
+# API Gateway default endpoint host from the AWS stack:
+#   terraform -chdir=green-room/terraform output -raw api_endpoint_host
+origin_host = "xxxxxxxxxx.execute-api.eu-north-1.amazonaws.com"
 
 # CI probe secret (shared with the GitHub Actions secret CF_PROBE_SECRET).
 # Generate a random value (e.g. openssl rand -hex 24). Leave empty to disable.

--- a/green-room/terraform/main.tf
+++ b/green-room/terraform/main.tf
@@ -131,8 +131,11 @@ resource "aws_apigatewayv2_api" "app" {
 }
 
 resource "aws_apigatewayv2_stage" "app" {
-  api_id      = aws_apigatewayv2_api.app.id
-  name        = var.environment
+  api_id = aws_apigatewayv2_api.app.id
+  # $default exposes the API at the base URL with no stage path, so Cloudflare
+  # can proxy meet.ankitraj.cloud straight to the API Gateway endpoint without a
+  # custom domain or ACM cert (Cloudflare terminates public TLS at the edge).
+  name        = "$default"
   auto_deploy = true
 
   access_log_settings {
@@ -177,25 +180,8 @@ resource "aws_lambda_permission" "api_gw" {
   source_arn    = "${aws_apigatewayv2_api.app.execution_arn}/*/*"
 }
 
-# ==================== Custom domain (meet.ankitraj.cloud) ====================
-# The ACM certificate is created out-of-band (the shared deploy role has ACM
-# read-only permissions), then its ARN is passed in via var.certificate_arn.
-# DNS (the app CNAME + the ACM validation CNAME) is managed in the Cloudflare
-# module (terraform/cloudflare).
-resource "aws_apigatewayv2_domain_name" "app" {
-  count       = var.enable_custom_domain ? 1 : 0
-  domain_name = var.domain_name
+# DNS for meet.ankitraj.cloud is handled entirely by Cloudflare
+# (terraform/cloudflare): a proxied CNAME to the API Gateway default endpoint.
+# Cloudflare provides the public TLS certificate (Universal SSL), so no API
+# Gateway custom domain or ACM certificate is required here.
 
-  domain_name_configuration {
-    certificate_arn = var.certificate_arn
-    endpoint_type   = "REGIONAL"
-    security_policy = "TLS_1_2"
-  }
-}
-
-resource "aws_apigatewayv2_api_mapping" "app" {
-  count       = var.enable_custom_domain ? 1 : 0
-  api_id      = aws_apigatewayv2_api.app.id
-  domain_name = aws_apigatewayv2_domain_name.app[0].id
-  stage       = aws_apigatewayv2_stage.app.id
-}

--- a/green-room/terraform/outputs.tf
+++ b/green-room/terraform/outputs.tf
@@ -10,12 +10,7 @@ output "lambda_function_name" {
   value       = aws_lambda_function.app.function_name
 }
 
-output "custom_domain_target" {
-  description = "API Gateway regional target domain, used as the Cloudflare CNAME content for meet.ankitraj.cloud."
-  value       = var.enable_custom_domain ? aws_apigatewayv2_domain_name.app[0].domain_name_configuration[0].target_domain_name : null
-}
-
-output "custom_domain_hosted_zone_id" {
-  description = "Hosted zone ID for the API Gateway regional custom domain."
-  value       = var.enable_custom_domain ? aws_apigatewayv2_domain_name.app[0].domain_name_configuration[0].hosted_zone_id : null
+output "api_endpoint_host" {
+  description = "API Gateway default endpoint host (Cloudflare CNAME target for meet.ankitraj.cloud)."
+  value       = replace(aws_apigatewayv2_api.app.api_endpoint, "https://", "")
 }

--- a/green-room/terraform/terraform.tfvars.example
+++ b/green-room/terraform/terraform.tfvars.example
@@ -5,12 +5,4 @@ aws_region   = "eu-north-1"
 environment  = "prod"
 project_name = "portfolio-ankit-greenroom"
 
-domain_name          = "meet.ankitraj.cloud"
-enable_custom_domain = true
-
-# ACM certificate for meet.ankitraj.cloud (regional, same region as aws_region).
-# Create it once with an admin identity, validate via the Cloudflare CNAME, then
-# paste the ARN here (or pass TF_VAR_certificate_arn in CI):
-#   aws acm request-certificate --domain-name meet.ankitraj.cloud \
-#     --validation-method DNS --region eu-north-1
-certificate_arn = "arn:aws:acm:eu-north-1:157539276388:certificate/REPLACE_ME"
+domain_name = "meet.ankitraj.cloud"

--- a/green-room/terraform/variables.tf
+++ b/green-room/terraform/variables.tf
@@ -24,18 +24,6 @@ variable "domain_name" {
   default     = "meet.ankitraj.cloud"
 }
 
-variable "enable_custom_domain" {
-  description = "Whether to provision the API Gateway custom domain + mapping. Requires a valid certificate_arn."
-  type        = bool
-  default     = true
-}
-
-variable "certificate_arn" {
-  description = "ACM certificate ARN for the custom domain, in the same region as aws_region. Created out-of-band because the shared deploy role has ACM read-only access."
-  type        = string
-  default     = ""
-}
-
 variable "log_retention_days" {
   description = "CloudWatch Logs retention (days) for the Lambda and API Gateway log groups. Lower values reduce storage cost."
   type        = number


### PR DESCRIPTION
## Problem
The `main` Green Room deploy failed at `terraform apply`:
```
BadRequestException: A certificate was not provided for the endpoint type REGIONAL.
```
The stack created a **regional API Gateway custom domain**, which mandates its own **AWS ACM certificate**. The shared OIDC deploy role is ACM read-only and no cert existed, so it could never succeed. That also contradicted the intent of using Cloudflare for certs.

## Fix
Drop the API Gateway custom domain + ACM entirely and let **Cloudflare be the only certificate**:
- API Gateway now uses a `$default` stage (no `/prod` path).
- Cloudflare proxies `meet.ankitraj.cloud` via a CNAME straight to the API Gateway default endpoint (`<id>.execute-api.eu-north-1.amazonaws.com`).
- **Public TLS:** Cloudflare Universal SSL at the edge. **Origin hop:** AWS's built-in `*.execute-api` cert (Full mode). Nothing to provision.

## Removed
- `aws_apigatewayv2_domain_name` + `aws_apigatewayv2_api_mapping`
- `certificate_arn` / `enable_custom_domain` variables
- ACM validation Cloudflare record + `GREENROOM_CERT_ARN` / `GREENROOM_ACM_VALIDATION_*` secrets

## Result
- No ACM cert or cert secrets needed. Required secrets: `AWS_ROLE_ARN`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID` (optional `CF_PROBE_SECRET`).
- The `main` deploy now provisions Lambda + API Gateway and wires DNS with no manual cert step.

## Validation
- `terraform fmt` clean; `terraform validate` passes for both modules.
- No residual ACM/cert references in code or workflow.