### PR TITLE
Green Room: Cloudflare Origin Rule to fix 403 on meet.ankitraj.cloud

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: 📋 Terraform Format Check
         id: fmt
-        run: terraform fmt -check -recursive
+        run: terraform fmt -check
         working-directory: terraform
         continue-on-error: true
 
@@ -295,6 +295,12 @@ jobs:
         working-directory: terraform
         env:
           TF_VAR_aws_region: ${{ env.AWS_REGION }}
+
+      - name: ☁️ Cloudflare Terraform Format Check
+        id: cf_fmt
+        run: terraform fmt -check
+        working-directory: terraform/cloudflare
+        continue-on-error: true
 
       - name: ☁️ Cloudflare Terraform Init
         id: cf_init
@@ -430,7 +436,7 @@ jobs:
               '',
               '| Check | AWS | Cloudflare |',
               '| :--- | :---: | :---: |',
-              `| Format | ${icon('${{ steps.fmt.outcome }}')} | n/a |`,
+              `| Format | ${icon('${{ steps.fmt.outcome }}')} | ${icon('${{ steps.cf_fmt.outcome }}')} |`,
               `| Init | ${icon('${{ steps.init.outcome }}')} | ${icon('${{ steps.cf_init.outcome }}')} |`,
               `| Validate | ${icon('${{ steps.validate.outcome }}')} | ${icon('${{ steps.cf_validate.outcome }}')} |`,
               `| Plan | ${icon('${{ steps.plan.outcome }}')} | ${icon('${{ steps.cf_plan.outcome }}')} |`,

--- a/green-room/terraform/cloudflare/main.tf
+++ b/green-room/terraform/cloudflare/main.tf
@@ -94,6 +94,31 @@ resource "cloudflare_record" "app" {
   comment = "meet.ankitraj.cloud to Green Room API Gateway endpoint"
 }
 
+# ==================== Origin Rule: Host header override ====================
+# API Gateway's default (regional) endpoint returns 403 for any Host header that
+# is not its own *.execute-api name. Cloudflare proxies the visitor's Host
+# (meet.ankitraj.cloud), so without this rule every request is rejected. This
+# Origin Rule rewrites only the Host header sent to the origin to the execute-api
+# host; SNI stays as the CNAME target, so it still matches AWS's built-in cert.
+resource "cloudflare_ruleset" "app_origin_host" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "Green Room origin Host header override"
+  description = "Send API Gateway's execute-api host as the origin Host header"
+  kind        = "zone"
+  phase       = "http_request_origin"
+
+  rules {
+    ref         = "greenroom_origin_host_override"
+    description = "Rewrite Host to the API Gateway endpoint for ${var.domain_name}"
+    expression  = "(http.host eq \"${var.domain_name}\")"
+    action      = "route"
+
+    action_parameters {
+      host_header = var.origin_host
+    }
+  }
+}
+
 # ==================== WAF: CI probe bypass (opt-in) ====================
 # Lets the GitHub Actions health/smoke probe skip Cloudflare bot management on
 # /health only, so CI runner IPs are not falsely challenged. Requires a token


### PR DESCRIPTION
## Problem
After the Cloudflare-only TLS change (#87) deployed successfully, the public URL still returned **403**:

```
https://meet.ankitraj.cloud/         -> 403
https://meet.ankitraj.cloud/health   -> 403
```

Root cause (confirmed by probing the origin directly):

```
curl .../health                                  -> 200   (default execute-api host)
curl -H "Host: meet.ankitraj.cloud" .../health   -> 403   (custom host)
```

The API Gateway v2 **default (regional) endpoint rejects any `Host` header that is not its own `*.execute-api` name**. Cloudflare proxies the visitor's `Host: meet.ankitraj.cloud` to the origin, so every request is refused.

## Fix
Add a Cloudflare **Origin Rule** (`http_request_origin` phase) that rewrites only the **Host header** sent to the origin to the API Gateway `execute-api` host:

- SNI stays as the CNAME target (`*.execute-api.eu-north-1.amazonaws.com`), so it still matches AWS's built-in certificate (Full mode).
- Public TLS is unchanged (Cloudflare Universal SSL at the edge).
- Applies only to `http.host eq "meet.ankitraj.cloud"`.

## Note
The Cloudflare API token must be able to edit Origin Rules (Zone > Config Rules / Origin Rules). If the deploy step fails with a permissions error, add that scope to `CLOUDFLARE_API_TOKEN`.

## Validation
- `terraform fmt` clean; `terraform validate` passes.
- Deploy on merge to `main` applies the rule via the existing Green Room Cloudflare step.