### PR TITLE
CI: show real Cloudflare terraform fmt result (drop n/a)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -262,7 +262,7 @@ jobs:
 
       - name: 📋 Terraform Format Check
         id: fmt
-        run: terraform fmt -check -recursive
+        run: terraform fmt -check
         working-directory: terraform
         continue-on-error: true
 
@@ -295,6 +295,12 @@ jobs:
         working-directory: terraform
         env:
           TF_VAR_aws_region: ${{ env.AWS_REGION }}
+
+      - name: ☁️ Cloudflare Terraform Format Check
+        id: cf_fmt
+        run: terraform fmt -check
+        working-directory: terraform/cloudflare
+        continue-on-error: true
 
       - name: ☁️ Cloudflare Terraform Init
         id: cf_init
@@ -430,7 +436,7 @@ jobs:
               '',
               '| Check | AWS | Cloudflare |',
               '| :--- | :---: | :---: |',
-              `| Format | ${icon('${{ steps.fmt.outcome }}')} | n/a |`,
+              `| Format | ${icon('${{ steps.fmt.outcome }}')} | ${icon('${{ steps.cf_fmt.outcome }}')} |`,
               `| Init | ${icon('${{ steps.init.outcome }}')} | ${icon('${{ steps.cf_init.outcome }}')} |`,
               `| Validate | ${icon('${{ steps.validate.outcome }}')} | ${icon('${{ steps.cf_validate.outcome }}')} |`,
               `| Plan | ${icon('${{ steps.plan.outcome }}')} | ${icon('${{ steps.cf_plan.outcome }}')} |`,


### PR DESCRIPTION
## What
The Terraform Plan Summary table posted on PRs showed `n/a` for the Cloudflare **Format** column:

| Check | AWS | Cloudflare |
|-------|-----|------------|
| Format | ✅ | n/a |

That was because the single AWS `terraform fmt -check -recursive` also (silently) covered the `terraform/cloudflare` subfolder, so there was no dedicated Cloudflare result to report.

## Change
- AWS format check is now non-recursive (`terraform fmt -check`) so the AWS column reflects only the AWS root module.
- Added a dedicated `cf_fmt` step (`terraform fmt -check` in `terraform/cloudflare`).
- The table's Format row now shows the real Cloudflare outcome instead of `n/a`.

Each column (Format / Init / Validate / Plan) now maps 1:1 to its own module. No functional deploy change; `continue-on-error: true` keeps formatting advisory, matching the existing AWS fmt behaviour.