### PR TITLE
CI: add -lock-timeout=5m to terraform plan/apply

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -280,7 +280,7 @@ jobs:
         id: plan
         run: |
           set +e
-          terraform plan -no-color -input=false -out=tfplan \
+          terraform plan -no-color -input=false -lock-timeout=5m -out=tfplan \
             -detailed-exitcode 2>&1 | tee plan.txt
           code=${PIPESTATUS[0]}
           echo "exitcode=$code" >> $GITHUB_OUTPUT
@@ -315,7 +315,7 @@ jobs:
       - name: ☁️ Cloudflare Terraform Plan
         id: cf_plan
         run: |
-          terraform plan -no-color -input=false 2>&1 | tee cf-plan.txt
+          terraform plan -no-color -input=false -lock-timeout=5m 2>&1 | tee cf-plan.txt
         working-directory: terraform/cloudflare
         continue-on-error: true
         env:
@@ -635,10 +635,10 @@ jobs:
           # Fall back to a fresh plan+apply if the artifact is unavailable.
           if [ -f tfplan ]; then
             echo "📋 Applying reviewed plan (tfplan)"
-            terraform apply -input=false tfplan
+            terraform apply -input=false -lock-timeout=5m tfplan
           else
             echo "⚠️ No saved plan found; planning and applying fresh"
-            terraform apply -auto-approve -input=false
+            terraform apply -auto-approve -input=false -lock-timeout=5m
           fi
 
           # Capture profile domain target for Cloudflare
@@ -652,7 +652,7 @@ jobs:
         run: |
           cd terraform/cloudflare
           terraform init -input=false
-          terraform apply -auto-approve -input=false
+          terraform apply -auto-approve -input=false -lock-timeout=5m
         env:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}

--- a/.github/workflows/green-room.yml
+++ b/.github/workflows/green-room.yml
@@ -117,7 +117,7 @@ jobs:
           terraform fmt -check -recursive || echo "::warning::terraform fmt drift"
           terraform init -input=false
           terraform validate -no-color
-          terraform plan -no-color -input=false -out=tfplan
+          terraform plan -no-color -input=false -lock-timeout=5m -out=tfplan
       - name: Upload plan
         uses: actions/upload-artifact@v4
         with:
@@ -183,7 +183,7 @@ jobs:
         working-directory: green-room/terraform
         run: |
           terraform init -input=false
-          terraform apply -auto-approve -input=false
+          terraform apply -auto-approve -input=false -lock-timeout=5m
       - name: Deploy Lambda code
         id: deploy
         working-directory: green-room/terraform
@@ -210,7 +210,7 @@ jobs:
             exit 0
           fi
           terraform init -input=false
-          terraform apply -auto-approve -input=false
+          terraform apply -auto-approve -input=false -lock-timeout=5m
       - name: Post-deployment health check (origin)
         run: |
           ORIGIN_URL="${{ steps.deploy.outputs.api_url }}"


### PR DESCRIPTION
Adds -lock-timeout=5m to every terraform plan/apply in green-room.yml and ci-cd.yml so brief DynamoDB state-lock contention (e.g. a PR plan overlapping a main apply on the same state key) waits instead of failing. The two workflows use disjoint state keys so they never lock each other; per-branch concurrency groups already serialize same-ref runs. This closes the cross-ref plan-vs-apply gap.