### PR TITLE
green-room CI: ESLint 9 flat config + bump actions to v5 (Node 24)

### DIFF
--- a/green-room/eslint.config.js
+++ b/green-room/eslint.config.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// Green Room: ESLint 9 flat config.
+// Browser scripts in public/ load via <script> tags and share globals, so
+// no-undef is relaxed there. Node files use CommonJS globals; the Cloudflare
+// Worker proxy is an ES module with its own runtime globals.
+
+const nodeGlobals = {
+  process: 'readonly',
+  console: 'readonly',
+  Buffer: 'readonly',
+  __dirname: 'readonly',
+  __filename: 'readonly',
+  module: 'writable',
+  require: 'readonly',
+  exports: 'writable',
+  globalThis: 'readonly',
+  fetch: 'readonly',
+  URL: 'readonly',
+  setTimeout: 'readonly',
+  clearTimeout: 'readonly',
+  setInterval: 'readonly',
+  clearInterval: 'readonly',
+};
+
+module.exports = [
+  {
+    ignores: ['node_modules/**'],
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'commonjs',
+      globals: nodeGlobals,
+    },
+    rules: {
+      'no-unused-vars': [
+        'warn',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      'no-undef': 'error',
+    },
+  },
+  {
+    // Browser single-page app: cross-file globals from <script> tags
+    // (GreenRoomCore, QUESTIONS) and Web APIs are provided by the runtime.
+    files: ['public/**/*.js'],
+    languageOptions: {
+      sourceType: 'script',
+    },
+    rules: {
+      'no-undef': 'off',
+    },
+  },
+  {
+    // Cloudflare Worker: ES module using the Workers runtime globals.
+    files: ['terraform/cloudflare/worker/**/*.js'],
+    languageOptions: {
+      sourceType: 'module',
+    },
+    rules: {
+      'no-undef': 'off',
+    },
+  },
+];

--- a/green-room/public/app.js
+++ b/green-room/public/app.js
@@ -982,7 +982,7 @@ delivery: ${a.eval.delivery.join(" | ") || "clean"}`).join("\n\n");
   renderHome(); // refresh history behind the scenes
 }
 
-function renderReport(s, isSaved) {
+function renderReport(s, _isSaved) {
   $("reportTitle").textContent = `${window.TRACKS[s.track]?.label || s.track} — session report`;
   $("reportMeta").textContent = `${new Date(s.date).toLocaleString()} · ${s.answers.length} answered · difficulty: ${s.difficulty}`;
 

--- a/green-room/server.js
+++ b/green-room/server.js
@@ -57,7 +57,6 @@ app.get('*', (req, res) => {
 if (require.main === module) {
   const port = process.env.PORT || 3000;
   app.listen(port, () => {
-    // eslint-disable-next-line no-console
     console.log(`Green Room running on http://localhost:${port}`);
   });
 }


### PR DESCRIPTION
Two CI-hygiene fixes for the green-room workflow.

## 1. ESLint flat config (fixes "Linting issues found")
`eslint .` errored because ESLint 9 needs a flat `eslint.config.js` and none existed (the step is `continue-on-error`, so it was a non-blocking warning). Added `green-room/eslint.config.js`:
- `public/**` browser scripts: `sourceType: script`, `no-undef` off (globals from `<script>` tags + Web APIs).
- Node files: CommonJS globals (`process`, `console`, `__dirname`, `fetch`, ...).
- Cloudflare Worker `proxy.js`: ES module.
- Cleared two residual warnings (unused param, unused disable directive).

`npm run lint` now exits 0.

## 2. Bump actions to v5 (fixes Node 20 deprecation warnings)
Matched the portfolio `ci-cd.yml`: `checkout`, `setup-node`, `upload-artifact`, `download-artifact`, and `configure-aws-credentials` bumped to `@v5` (Node 24). `setup-terraform` stays `@v3` (no newer major yet), same as ci-cd.yml.

## Scope
`green-room/` + `.github/workflows/green-room.yml`.