### PR TITLE
ci: bump all Actions to latest majors + Dependabot grouping & auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
     labels:
       - ci
     commit-message:
       prefix: "ci(deps):"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/agentic-resume-foundry.yml
+++ b/.github/workflows/agentic-resume-foundry.yml
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -90,7 +90,7 @@ jobs:
 
       - name: ♻️ Cache Puppeteer Chromium
         id: puppeteer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: 📤 Upload Resume PDF
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: resume-pdf-foundry
           path: public/assets/Profile-*.pdf
@@ -183,7 +183,7 @@ jobs:
 
       - name: 📤 Upload ATS Report
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ats-report-foundry
           path: public/assets/*-ats-report.json
@@ -191,7 +191,7 @@ jobs:
 
       - name: 📤 Upload Debug HTML
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-html-foundry
           path: public/assets/resume-debug.html

--- a/.github/workflows/agentic-resume.yml
+++ b/.github/workflows/agentic-resume.yml
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -86,7 +86,7 @@ jobs:
 
       - name: ♻️ Cache Puppeteer Chromium
         id: puppeteer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: 📤 Upload Resume PDF
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: resume-pdf
           path: public/assets/Profile-*.pdf
@@ -178,7 +178,7 @@ jobs:
 
       - name: 📤 Upload ATS Report
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ats-report
           path: public/assets/*-ats-report.json
@@ -186,7 +186,7 @@ jobs:
 
       - name: 📤 Upload Debug HTML
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-html
           path: public/assets/resume-debug.html

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,12 +102,12 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for better analysis
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -135,7 +135,7 @@ jobs:
         continue-on-error: true
 
       - name: 📊 Upload Code Quality Reports
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: code-quality-reports
@@ -153,7 +153,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Secret detection is handled by GitHub-native Secret Scanning +
       # Push Protection (repo Settings > Code security), not a third-party
@@ -169,7 +169,7 @@ jobs:
       # CodeQL (codeql.yml), and npm audit in the code-quality job.
       - name: 🔎 Dependency Review (GitHub Advisory DB)
         if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -186,10 +186,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -220,10 +220,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -234,7 +234,7 @@ jobs:
           ./scripts/build-lambda.sh
 
       - name: 🔧 Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -244,14 +244,14 @@ jobs:
       # `id-token: write` permission and the IAM role + OIDC provider from
       # terraform/github-oidc/. Set the AWS_ROLE_ARN repo secret to the role ARN.
       - name: 🔑 Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gha-tf-validate-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: ♻️ Cache Terraform Providers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             terraform/.terraform
@@ -331,7 +331,7 @@ jobs:
           TF_VAR_ci_probe_secret: ${{ secrets.CF_PROBE_SECRET }}
 
       - name: 📤 Upload Terraform Plan
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-plan
           path: |
@@ -341,7 +341,7 @@ jobs:
           retention-days: 7
 
       - name: 💬 PR Comment - Terraform Plan
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         with:
           script: |
@@ -505,10 +505,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -534,7 +534,7 @@ jobs:
           echo "   Artifact: $ARTIFACT_NAME"
 
       - name: 📤 Upload Build Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.artifact_name }}
           path: terraform/portfolio-lambda.zip
@@ -572,10 +572,10 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🔧 Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
@@ -583,14 +583,14 @@ jobs:
       # Keyless auth via GitHub OIDC (see terraform/github-oidc/). No static
       # AWS keys: a short-lived role session is minted per run.
       - name: 🔑 Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gha-deploy-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: 📥 Download Build Artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build.outputs.artifact_name }}
           path: terraform/
@@ -620,7 +620,7 @@ jobs:
 
       - name: 📥 Download Reviewed Terraform Plan
         if: github.event.inputs.deploy_type != 'lambda-only'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: terraform-plan
           path: terraform/
@@ -802,7 +802,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🔥 Run Smoke Tests
         env:
@@ -949,7 +949,7 @@ jobs:
       # Keyless auth via GitHub OIDC (see terraform/github-oidc/) for the
       # SES notification below.
       - name: 🔑 Configure AWS Credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gha-notify-${{ github.run_id }}
@@ -1000,7 +1000,7 @@ jobs:
     
     steps:
       - name: 📝 Create PR Summary Comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const codeQuality = '${{ needs.code-quality.result }}';

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs for minor and patch updates once required
+# checks pass. Major updates are left for manual review (possible breaking
+# changes). Requires "Allow auto-merge" enabled on the repository.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 📝 Lint Markdown Files
         uses: DavidAnson/markdownlint-cli2-action@v18

--- a/.github/workflows/green-room.yml
+++ b/.github/workflows/green-room.yml
@@ -50,8 +50,8 @@ jobs:
       run:
         working-directory: green-room
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -71,8 +71,8 @@ jobs:
       run:
         working-directory: green-room
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -92,8 +92,8 @@ jobs:
     name: Terraform Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -103,12 +103,12 @@ jobs:
         run: |
           chmod +x scripts/build-lambda.sh
           ./scripts/build-lambda.sh
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gha-greenroom-validate-${{ github.run_id }}
@@ -121,7 +121,7 @@ jobs:
           terraform validate -no-color
           terraform plan -no-color -input=false -out=tfplan
       - name: Upload plan
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: greenroom-tfplan
           path: green-room/terraform/tfplan
@@ -134,8 +134,8 @@ jobs:
     outputs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -148,7 +148,7 @@ jobs:
           ./scripts/build-lambda.sh
           HASH=$(sha256sum terraform/greenroom-lambda.zip | cut -d ' ' -f1 | head -c 8)
           echo "artifact_name=greenroom-${GITHUB_SHA::8}-${HASH}" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.artifact_name }}
           path: green-room/terraform/greenroom-lambda.zip
@@ -165,19 +165,19 @@ jobs:
     outputs:
       api_url: ${{ steps.deploy.outputs.api_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v7
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: gha-greenroom-deploy-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ needs.build.outputs.artifact_name }}
           path: green-room/terraform/

--- a/.github/workflows/resume-nordic-pdf.yml
+++ b/.github/workflows/resume-nordic-pdf.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
 
       - name: Cache Puppeteer Chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -40,7 +40,7 @@ jobs:
         run: node scripts/generate-pdf-photo.js
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: Profile-Nordic
           path: public/assets/Profile-Nordic.pdf

--- a/.github/workflows/resume-pdf.yml
+++ b/.github/workflows/resume-pdf.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
 
       - name: Cache Puppeteer Chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -39,7 +39,7 @@ jobs:
         run: node scripts/generate-pdf.js
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: Profile-ATS
           path: public/assets/Profile.pdf


### PR DESCRIPTION
Repo-wide GitHub Actions modernization: every action across all **8** workflows moved to its current latest major (all Node 24), plus a self-maintaining Dependabot setup so future bumps are hands-off.

## 1. Action version bumps (clears Node 20 deprecation annotations)
| action | before | after |
|---|---|---|
| actions/checkout | v4/v5 | v7 |
| actions/setup-node | v4/v5 | v7 |
| actions/upload-artifact | v4/v5 | v7 |
| actions/download-artifact | v4/v5 | v8 |
| actions/cache | v4 | v6 |
| actions/github-script | v8 | v9 |
| actions/dependency-review-action | v4 | v5 |
| aws-actions/configure-aws-credentials | v4/v5 | v6 |
| hashicorp/setup-terraform | v3 | v4 |

Files: ci-cd.yml, green-room.yml, agentic-resume.yml, agentic-resume-foundry.yml, resume-pdf.yml, resume-nordic-pdf.yml, codeql.yml, docs-lint.yml.
Left as-is (already latest major): github/codeql-action@v4, gaurav-nelson/github-action-markdown-link-check@v1.

## 2. Dependabot: grouped + auto-merge
- `dependabot.yml`: the `github-actions` ecosystem is grouped into **one weekly PR** (was one PR per action), with `open-pull-requests-limit: 10`.
- New `dependabot-automerge.yml`: enables **auto-merge (squash)** for **minor + patch** Dependabot updates once checks pass; **major** updates stay manual (possible breaking changes). Uses `dependabot/fetch-metadata@v2`.
- Repo setting `Allow auto-merge` enabled.

## Notes
No workflow logic changed; `terraform_wrapper: false` already set; all YAML validated locally. After merge, action upgrades are effectively hands-off: a weekly grouped Dependabot PR that self-merges for minor/patch.