### PR TITLE
ci: bump actions to latest majors across remaining workflows (Node 24)

### DIFF
--- a/.github/workflows/agentic-resume-foundry.yml
+++ b/.github/workflows/agentic-resume-foundry.yml
@@ -77,10 +77,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -90,7 +90,7 @@ jobs:
 
       - name: ♻️ Cache Puppeteer Chromium
         id: puppeteer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: 📤 Upload Resume PDF
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: resume-pdf-foundry
           path: public/assets/Profile-*.pdf
@@ -183,7 +183,7 @@ jobs:
 
       - name: 📤 Upload ATS Report
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ats-report-foundry
           path: public/assets/*-ats-report.json
@@ -191,7 +191,7 @@ jobs:
 
       - name: 📤 Upload Debug HTML
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-html-foundry
           path: public/assets/resume-debug.html

--- a/.github/workflows/agentic-resume.yml
+++ b/.github/workflows/agentic-resume.yml
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 🟢 Setup Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -86,7 +86,7 @@ jobs:
 
       - name: ♻️ Cache Puppeteer Chromium
         id: puppeteer-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -170,7 +170,7 @@ jobs:
 
       - name: 📤 Upload Resume PDF
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: resume-pdf
           path: public/assets/Profile-*.pdf
@@ -178,7 +178,7 @@ jobs:
 
       - name: 📤 Upload ATS Report
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ats-report
           path: public/assets/*-ats-report.json
@@ -186,7 +186,7 @@ jobs:
 
       - name: 📤 Upload Debug HTML
         if: success()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: debug-html
           path: public/assets/resume-debug.html

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: 📥 Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: 📝 Lint Markdown Files
         uses: DavidAnson/markdownlint-cli2-action@v18

--- a/.github/workflows/resume-nordic-pdf.yml
+++ b/.github/workflows/resume-nordic-pdf.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
 
       - name: Cache Puppeteer Chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -40,7 +40,7 @@ jobs:
         run: node scripts/generate-pdf-photo.js
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: Profile-Nordic
           path: public/assets/Profile-Nordic.pdf

--- a/.github/workflows/resume-pdf.yml
+++ b/.github/workflows/resume-pdf.yml
@@ -16,16 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
 
       - name: Cache Puppeteer Chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -39,7 +39,7 @@ jobs:
         run: node scripts/generate-pdf.js
 
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: Profile-ATS
           path: public/assets/Profile.pdf


### PR DESCRIPTION
Completes the repo-wide action-version cleanup so no workflow triggers Node 20 deprecation warnings. Covers the 6 workflows not already handled by #93 (green-room) and #94 (ci-cd).

| action | before | after |
|---|---|---|
| actions/checkout | v5 | v7 |
| actions/setup-node | v5 | v7 |
| actions/upload-artifact | v5 | v7 |
| actions/cache | v4 | v6 |

Files: agentic-resume.yml, agentic-resume-foundry.yml, resume-pdf.yml, resume-nordic-pdf.yml, codeql.yml, docs-lint.yml.

Left as-is (already latest major): github/codeql-action@v4, gaurav-nelson/github-action-markdown-link-check@v1. No workflow logic changed; all 6 YAML files validated locally.