### PR TITLE
ci+docs: path-aware Terraform, Dependabot skip, and README/docs reorg

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -215,6 +215,11 @@ jobs:
   terraform-validate:
     name: 🏗️ Terraform Validation
     runs-on: ubuntu-latest
+    # Dependabot PRs run with a read-only token and no access to repo secrets or
+    # OIDC, so AWS_ROLE_ARN is empty and the plan cannot authenticate. Skip this
+    # job for Dependabot; the plan artifact is only consumed by the deploy job
+    # (push to main), never on a PR, so nothing downstream is affected.
+    if: github.actor != 'dependabot[bot]'
     outputs:
       plan_exitcode: ${{ steps.plan.outputs.exitcode }}
     
@@ -497,7 +502,7 @@ jobs:
       always() &&
       (needs.code-quality.result == 'success' || needs.code-quality.result == 'skipped') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped') &&
-      (needs.terraform-validate.result == 'success')
+      (needs.terraform-validate.result == 'success' || needs.terraform-validate.result == 'skipped')
     outputs:
       artifact_name: ${{ steps.build.outputs.artifact_name }}
       package_size: ${{ steps.build.outputs.package_size }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,6 +91,31 @@ permissions:
 
 jobs:
   # ============================================================================
+  # Stage 0: Change Detection
+  # ============================================================================
+  # Detect whether infrastructure files changed so we can skip the (slow,
+  # AWS-authenticated) Terraform plan on app-only PRs. On push/dispatch the
+  # gate below always runs Terraform so deploy still gets its plan artifact.
+  detect-changes:
+    name: 🔎 Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: 🔎 Filter Paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            infra:
+              - 'terraform/**'
+              - 'scripts/build-lambda.sh'
+              - '.github/workflows/ci-cd.yml'
+
+  # ============================================================================
   # Stage 1: Code Quality & Security Analysis
   # ============================================================================
   code-quality:
@@ -215,11 +240,15 @@ jobs:
   terraform-validate:
     name: 🏗️ Terraform Validation
     runs-on: ubuntu-latest
-    # Dependabot PRs run with a read-only token and no access to repo secrets or
-    # OIDC, so AWS_ROLE_ARN is empty and the plan cannot authenticate. Skip this
-    # job for Dependabot; the plan artifact is only consumed by the deploy job
-    # (push to main), never on a PR, so nothing downstream is affected.
-    if: github.actor != 'dependabot[bot]'
+    needs: [detect-changes]
+    # Run Terraform only when it can and should:
+    #  - never for Dependabot (read-only token, no secrets/OIDC to assume the AWS role);
+    #  - always on push to main / manual dispatch (deploy needs the plan artifact);
+    #  - on PRs, only when infra files actually changed (skip the slow AWS plan
+    #    for app-only PRs). The downstream build gate accepts a skipped result.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || needs.detect-changes.outputs.infra == 'true')
     outputs:
       plan_exitcode: ${{ steps.plan.outputs.exitcode }}
     
@@ -1001,7 +1030,7 @@ jobs:
     name: 📝 PR Summary
     runs-on: ubuntu-latest
     needs: [code-quality, security-scan, terraform-validate, build]
-    if: github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     
     steps:
       - name: 📝 Create PR Summary Comment

--- a/README.md
+++ b/README.md
@@ -150,11 +150,13 @@ Pushes to `main` and pull requests run the full pipeline. All AWS access is keyl
 
 ```mermaid
 flowchart LR
-    TRIG[Push to main / PR]:::trigger --> CQ[Code Quality]
+    TRIG[Push to main / PR]:::trigger --> DET[Detect Changes]
+    DET --> CQ[Code Quality]
     CQ --> SS[Security Scan]
     SS --> TST[Tests]
-    TST --> TFV[Terraform Validate]
-    TFV --> BLD[Build]
+    TST --> TFV{Terraform Validate<br/>infra changed?}
+    TFV -- yes / push to main --> BLD[Build]
+    TFV -. app-only PR: skipped .-> BLD
     BLD --> DEP[Deploy]
     DEP --> SMK[Smoke Tests]
     SMK --> NTF[Notify]
@@ -165,6 +167,8 @@ flowchart LR
     classDef trigger fill:#2563eb,stroke:#1e40af,color:#fff
     classDef aws fill:#ff9900,stroke:#cc7a00,color:#000
 ```
+
+Terraform Validation is **path-aware**: on pull requests it runs only when infrastructure files (`terraform/**`, the Lambda build script, or this workflow) change, so app-only PRs skip the slow AWS plan. Pushes to `main` and manual dispatch always run it so `deploy` gets a fresh plan. Dependabot PRs skip it entirely (their read-only token cannot assume the AWS role).
 
 See [docs/cicd.md](docs/cicd.md) for the full workflow reference and stage detail.
 
@@ -181,7 +185,8 @@ See [docs/cicd.md](docs/cicd.md) for the full workflow reference and stage detai
 ### Dependabot
 
 - **npm**: weekly Monday updates, grouped by dev/prod
-- **GitHub Actions**: weekly Monday updates, grouped
+- **GitHub Actions**: weekly Monday updates, grouped into a single PR
+- **Auto-merge**: minor + patch updates (all ecosystems) and **all** GitHub Actions updates auto-merge (squash) once checks pass; npm majors stay manual. Handled by `dependabot-automerge.yml` with repo `Allow auto-merge` enabled.
 - **Labels**: `dependencies`, `ci`
 - **PR limit**: 10 open PRs max
 

--- a/README.md
+++ b/README.md
@@ -120,98 +120,17 @@ node scripts/generate-pdf-photo.js
 | `npm run deploy` | Deploy to AWS via Terraform |
 | `npm run deploy:destroy` | Tear down AWS infrastructure |
 
-## 🏗️ Infrastructure
+## 🔄 CI/CD & Infrastructure
 
-### AWS Resources
+Serverless on **AWS Lambda + API Gateway** (eu-north-1), fronted by **Cloudflare** DNS/SSL, provisioned with **Terraform** (remote state in S3 + DynamoDB lock). Pushes to `main` and PRs run the full GitHub Actions pipeline; all AWS access is keyless via GitHub OIDC (no static keys).
 
-- **Lambda Function** `portfolio-ankit-prod-*` (Node.js 22.x, 512MB, 30s timeout)
-- **API Gateway** HTTP API v2 with CORS
-- **ACM Certificate** SSL for custom domain
-- **SES** email sending with DKIM verified
-- **S3** static assets and Terraform state
-- **CloudWatch** logs (14-day retention) and metrics
+Terraform Validation is **path-aware** — on PRs it runs only when infra files change, and Dependabot PRs skip it. Dependabot updates are grouped, and minor/patch (plus all GitHub Actions) auto-merge once checks pass.
 
-### Cloudflare
-
-- **DNS** A, CNAME, TXT records
-- **SSL** Full (strict) mode
-- **Page Rules** root domain redirect to www
-
-### Remote State
-
-Terraform state is stored in S3 with DynamoDB locking:
-
-- **Bucket**: `portfolio-ankit-terraform-state`
-- **Lock Table**: `portfolio-ankit-terraform-locks`
-
-## 🔄 CI/CD Pipeline
-
-Pushes to `main` and pull requests run the full pipeline. All AWS access is keyless: every AWS-touching job assumes an IAM role via GitHub OIDC, so no static AWS keys are stored.
-
-```mermaid
-flowchart LR
-    TRIG[Push to main / PR]:::trigger --> DET[Detect Changes]
-    DET --> CQ[Code Quality]
-    CQ --> SS[Security Scan]
-    SS --> TST[Tests]
-    TST --> TFV{Terraform Validate<br/>infra changed?}
-    TFV -- yes / push to main --> BLD[Build]
-    TFV -. app-only PR: skipped .-> BLD
-    BLD --> DEP[Deploy]
-    DEP --> SMK[Smoke Tests]
-    SMK --> NTF[Notify]
-
-    TFV -. OIDC .-> AWS[(AWS eu-north-1)]:::aws
-    DEP -. OIDC .-> AWS
-
-    classDef trigger fill:#2563eb,stroke:#1e40af,color:#fff
-    classDef aws fill:#ff9900,stroke:#cc7a00,color:#000
-```
-
-Terraform Validation is **path-aware**: on pull requests it runs only when infrastructure files (`terraform/**`, the Lambda build script, or this workflow) change, so app-only PRs skip the slow AWS plan. Pushes to `main` and manual dispatch always run it so `deploy` gets a fresh plan. Dependabot PRs skip it entirely (their read-only token cannot assume the AWS role).
-
-See [docs/cicd.md](docs/cicd.md) for the full workflow reference and stage detail.
-
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| **ci-cd.yml** | Push / PR to `main` | Full pipeline: quality, scan, test, terraform, build, deploy, smoke |
-| **codeql.yml** | Push/PR to `main` + weekly | CodeQL security analysis for JavaScript |
-| **resume-pdf.yml** | Push (resume HTML changes) + manual | Regenerate Profile.pdf |
-| **resume-nordic-pdf.yml** | Push (resume-photo.html changes) + manual | Regenerate Profile-Nordic.pdf |
-| **agentic-resume.yml** | Push (`jds/*.txt`) + manual | 4-agent resume pipeline via Claude (Anthropic) |
-| **agentic-resume-foundry.yml** | Push (`jds/*.txt`) + manual | 4-agent resume pipeline via Azure OpenAI (Foundry) |
-| **docs-lint.yml** | Push/PR (docs changes) | Markdown lint and link check |
-
-### Dependabot
-
-- **npm**: weekly Monday updates, grouped by dev/prod
-- **GitHub Actions**: weekly Monday updates, grouped into a single PR
-- **Auto-merge**: minor + patch updates (all ecosystems) and **all** GitHub Actions updates auto-merge (squash) once checks pass; npm majors stay manual. Handled by `dependabot-automerge.yml` with repo `Allow auto-merge` enabled.
-- **Labels**: `dependencies`, `ci`
-- **PR limit**: 10 open PRs max
-
-### Required Secrets
-
-See [docs/deployment.md](docs/deployment.md) for the full secrets and IAM permissions.
-
-## 🔁 Application Lifecycle
-
-```mermaid
-flowchart LR
-    DEV[Local dev]:::dev --> VAL[npm run validate]
-    VAL --> PR[Open PR to main]
-    PR --> CI[CI checks]
-    CI --> MERGE[Merge to main]:::main
-    MERGE --> CD[Keyless deploy via Terraform]
-    CD --> INFRA[AWS Lambda + API Gateway]:::aws
-    INFRA --> CDN[Cloudflare DNS + SSL]
-    CDN --> PROD[Live: www.ankitraj.cloud]:::prod
-
-    classDef dev fill:#10b981,stroke:#047857,color:#fff
-    classDef main fill:#2563eb,stroke:#1e40af,color:#fff
-    classDef aws fill:#ff9900,stroke:#cc7a00,color:#000
-    classDef prod fill:#7c3aed,stroke:#5b21b6,color:#fff
-```
+| Topic | Doc |
+|-------|-----|
+| Architecture + AWS/Cloudflare resources + security | [docs/architecture.md](docs/architecture.md) |
+| Pipeline stages, workflows, Dependabot | [docs/cicd.md](docs/cicd.md) |
+| Deployment, Terraform config, secrets | [docs/deployment.md](docs/deployment.md) |
 
 ## 🤖 Agentic Resume Pipeline
 
@@ -246,33 +165,12 @@ See [docs/architecture.md](docs/architecture.md) for full resource details.
 ## 🧪 Testing
 
 ```bash
-npm test
-
-# Expected output:
-# 🧪 Running Server Tests...
-# ✅ Health endpoint returns 200
-# ✅ Health endpoint returns JSON
-# ✅ Homepage returns HTML
-# ✅ Static CSS is served
-# ✅ Static JS is served
-# ✅ Contact API requires fields
-# ✅ Contact API validates email
-# ✅ Unknown routes return index.html (SPA)
-# 📊 Results: 8 passed, 0 failed
+npm test   # 8 unit tests (health, homepage, static assets, contact API, SPA fallback)
 ```
 
 ## 🛡️ Security
 
-- **CodeQL** static analysis for JavaScript vulnerabilities
-- **Dependabot** automated dependency updates
-- **npm audit** CI check for known CVEs (0 vulnerabilities)
-- **Dependency Review** blocks vulnerable dependencies on PRs (GitHub Advisory DB)
-- **Secret Scanning + Push Protection** native secret detection
-- **OIDC** keyless AWS deploys (no static credentials in CI)
-- **npm overrides** pinned `fast-xml-parser >=5.3.8` to patch CVEs
-- **IAM** least-privilege roles for Lambda and deploy
-- **API Gateway** throttling configured
-- **HTTPS** full strict SSL via Cloudflare
+CodeQL, Dependabot, npm audit, Dependency Review, Secret Scanning + Push Protection, keyless OIDC deploys, least-privilege IAM, and full-strict HTTPS. See [docs/architecture.md](docs/architecture.md#security) for the full posture.
 
 ## 🚢 Deployment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,19 @@ Change detection uses `dorny/paths-filter`; the infra path list lives in the `de
 
 See [cicd.md](cicd.md) for the full stage-by-stage reference.
 
+## Security
+
+- **CodeQL** — static analysis for JavaScript vulnerabilities (push/PR + weekly).
+- **Dependabot** — automated dependency updates (see [cicd.md](cicd.md#dependabot)).
+- **npm audit** — CI check for known CVEs (0 vulnerabilities).
+- **Dependency Review** — blocks vulnerable dependencies on PRs (GitHub Advisory DB).
+- **Secret Scanning + Push Protection** — native secret detection.
+- **OIDC** — keyless AWS deploys; no static credentials in CI.
+- **npm overrides** — pinned `fast-xml-parser >=5.3.8` to patch CVEs.
+- **IAM** — least-privilege roles for Lambda and deploy.
+- **API Gateway** — request throttling configured.
+- **HTTPS** — full strict SSL via Cloudflare.
+
 ## Agentic Resume Pipeline
 
 See [agentic-pipeline.md](agentic-pipeline.md) for the full 4-agent AI architecture.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,30 @@ State file locations:
 - AWS: `s3://portfolio-ankit-terraform-state/portfolio/aws/terraform.tfstate`
 - Cloudflare: `s3://portfolio-ankit-terraform-state/portfolio/cloudflare/terraform.tfstate`
 
+## CI/CD Pipeline
+
+The `ci-cd.yml` workflow gates deploys behind quality, security, and infrastructure checks. All AWS access is keyless via GitHub OIDC (no static keys).
+
+```text
+Detect Changes → Code Quality → Security Scan → Tests → Terraform Validate* → Build → Deploy → Smoke Tests → Notify
+```
+
+`*` Terraform Validation is conditional:
+
+- **Push to `main` / manual dispatch** — always runs, producing the plan the `deploy` job applies.
+- **Pull request** — runs only when infra files changed (`terraform/**`, `scripts/build-lambda.sh`, or `ci-cd.yml`), detected by the `detect-changes` job. App-only PRs skip it, and `build` accepts the skipped result.
+- **Dependabot PRs** — always skipped (read-only token cannot assume the AWS role via OIDC).
+
+Change detection uses `dorny/paths-filter`; the infra path list lives in the `detect-changes` job.
+
+### Dependency automation (Dependabot)
+
+- **npm** — weekly, grouped by dev/prod; minor + patch auto-merge, majors manual.
+- **GitHub Actions** — weekly, grouped into one PR; all update types (including majors) auto-merge.
+- Auto-merge is driven by `dependabot-automerge.yml` (squash, after checks pass) with the repo-level `Allow auto-merge` setting enabled.
+
+See [cicd.md](cicd.md) for the full stage-by-stage reference.
+
 ## Agentic Resume Pipeline
 
 See [agentic-pipeline.md](agentic-pipeline.md) for the full 4-agent AI architecture.

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -4,33 +4,38 @@
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci-cd.yml` | Push to `main`, PRs to `main` | Full pipeline: lint → scan → test → build → deploy → smoke test |
+| `ci-cd.yml` | Push to `main`, PRs to `main` | Full pipeline: detect changes → quality → scan → test → terraform → build → deploy → smoke |
 | `codeql.yml` | Push/PR to `main` + weekly | CodeQL static analysis for JavaScript |
-| `security-audit.yml` | Push/PR (package changes) | npm audit + outdated packages |
 | `resume-pdf.yml` | Push (`resume-aws-sa.html`) + manual | Auto-regenerate Profile.pdf |
 | `resume-nordic-pdf.yml` | Push (`resume-photo.html`) + manual | Auto-regenerate Profile-Nordic.pdf |
 | `agentic-resume.yml` | Push (`jds/*.txt`) + manual | 4-agent resume pipeline via Anthropic Claude |
 | `agentic-resume-foundry.yml` | Push (`jds/*.txt`) + manual | 4-agent resume pipeline via Azure OpenAI (Foundry) |
-| `dependency-update.yml` | Weekly (Sunday 2am UTC) | Check for dependency updates |
+| `docs-lint.yml` | Push/PR (docs changes) | Markdown lint and link check |
+| `dependabot-automerge.yml` | Dependabot PRs | Auto-merge dependency updates once checks pass |
 
 ## Main CI/CD Pipeline Stages
 
 ```text
-Code Quality → Security Scan → Tests → Terraform Validate → Build → Deploy → Smoke Tests → Notify
+Detect Changes → Code Quality → Security Scan → Tests → Terraform Validate* → Build → Deploy → Smoke Tests → Notify
 ```
+
+`*` Terraform Validation is conditional (see the gate below).
 
 ```mermaid
 flowchart TD
-    PR[Pull Request to main]:::trigger --> CQ
-    PUSH[Push to main]:::trigger --> CQ
+    PR[Pull Request to main]:::trigger --> DET
+    PUSH[Push to main]:::trigger --> DET
 
+    DET[0. Detect Changes<br/>infra path filter] --> CQ
     CQ[1. Code Quality<br/>ESLint, Prettier, npm audit] --> SS[2. Security Scan<br/>Dependency Review, Secret Scanning]
     SS --> TST[3. Tests<br/>8 unit tests]
-    TST --> TFV[4. Terraform Validate<br/>fmt, init, validate, plan]
+    TST --> TFV{4. Terraform Validate<br/>run this job?}
+    TFV -- "push to main / infra changed" --> TFRUN[fmt, init, validate, plan]
+    TFV -. "app-only PR / Dependabot: skipped" .-> BLD
 
-    TFV -. OIDC AssumeRoleWithWebIdentity .-> AWS[(AWS<br/>eu-north-1)]:::aws
+    TFRUN -. OIDC AssumeRoleWithWebIdentity .-> AWS[(AWS<br/>eu-north-1)]:::aws
 
-    TFV --> GATE{Push to main?}
+    TFRUN --> GATE{Push to main?}
     GATE -- "PR only" --> STOP[Stop: plan posted as PR comment]:::stop
     GATE -- "yes" --> BLD[5. Build<br/>Lambda package]
     BLD --> DEP[6. Deploy<br/>terraform apply + Lambda update]
@@ -45,12 +50,21 @@ flowchart TD
 
 > AWS access is keyless: every AWS-touching job assumes the `portfolio-ankit-github-deploy` IAM role via GitHub OIDC (`id-token: write` + `AWS_ROLE_ARN`). No static AWS keys are stored.
 
+### Path-aware Terraform Validation
+
+The `detect-changes` job (using `dorny/paths-filter`) decides whether the Terraform job runs:
+
+- **Push to `main` / manual dispatch** — always runs, producing the plan the `deploy` job applies.
+- **Pull request** — runs only when infra files changed (`terraform/**`, `scripts/build-lambda.sh`, or `ci-cd.yml`). App-only PRs skip it, and the `build` gate accepts the skipped result.
+- **Dependabot PRs** — always skipped (read-only token cannot assume the AWS role via OIDC).
+
 | Stage | Job | What it does |
 |-------|-----|-------------|
+| 0 | `detect-changes` | Path filter: did infra files change? |
 | 1 | `code-quality` | ESLint, Prettier, npm audit |
 | 2 | `security-scan` | Dependency Review (GitHub Advisory DB) + Secret Scanning |
 | 3 | `test` | Unit tests (8 cases) |
-| 4 | `terraform-validate` | IaC format check + plan |
+| 4 | `terraform-validate` | IaC format check + plan (conditional) |
 | 5 | `build` | Lambda package creation |
 | 6 | `deploy` | Terraform apply + Lambda update |
 | 7 | `smoke-tests` | Post-deploy health checks |
@@ -87,8 +101,9 @@ Changes to `scripts/agent/**` do **not** trigger the main CI/CD pipeline (docs/a
 
 ## Dependabot
 
-- **npm** — Weekly Monday updates, grouped by dev/prod
-- **GitHub Actions** — Weekly Monday updates
+- **npm** — weekly Monday updates, grouped by dev/prod; minor + patch auto-merge, majors manual.
+- **GitHub Actions** — weekly Monday updates, grouped into one PR; all update types (including majors) auto-merge.
+- **Auto-merge** — `dependabot-automerge.yml` enables auto-merge (squash) once checks pass, gated on update type + ecosystem; requires the repo `Allow auto-merge` setting.
 - **Labels**: `dependencies`, `ci`
 - **PR limit**: 10 open PRs max
 


### PR DESCRIPTION
Follow-up to #98, which squash-merged only the first commit. This carries the remaining four changes:

- ci: skip Terraform Validation for Dependabot PRs (read-only token cannot assume the AWS role).
- ci: make Terraform Validation path-aware via a detect-changes job so app-only PRs skip the AWS plan; push/dispatch still always run it.
- docs: reflect path-aware Terraform + Dependabot auto-merge in README and docs/architecture.md.
- docs: trim README (~340 to ~198 lines) and move CI/security detail into docs/cicd.md and docs/architecture.md.

markdownlint clean; ci-cd.yml YAML validated.